### PR TITLE
Fix build on windows

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -2,13 +2,9 @@ AM_CPPFLAGS = -DLISP_PATH=\"$(roslispdir)\" -DMAN_PATH=\"$(mandir)\"
 roslispdir = $(datadir)/common-lisp/source/$(PACKAGE)
 
 gend.h: FORCE
-	printf "#define ROS_COMPILE_ENVIRONMENT \"%s\"\n" "`$(CC) --version|head -n 1`" > $@.tmp
-	(printf "#define ROS_REVISION \"" && ((which git>/dev/null&&[ -e ../.git ]&& \
-	(git log -n 1 --oneline|cut -d' ' -f1| tr -d '\n'| tr -d '\r'))||printf "") && printf "\"\n") >> $@.tmp
-	(sh -c 'cd $(roslispdir); pwd -W' 2>&1 >/dev/null && (printf "#define WIN_LISP_PATH \"" \
-	echo `sh -c 'cd $(roslispdir); pwd -W 2>/dev/null'`| tr -d '\n'| tr -d '\r' |\
-	sed /\//\\/ \
-	printf "\\\\\"\n")  >> $@.tmp) || printf ""
+	printf '#define ROS_COMPILE_ENVIRONMENT "%s"\n' "`$(CC) --version|head -n 1`" > $@.tmp
+	which git>/dev/null && [ -e ../.git ] && printf "#define ROS_REVISION \"%s\"\n" "`git log -n 1 --oneline|cut -d' ' -f1`" >> $@.tmp
+	printf '#define WIN_LISP_PATH \"%s\"' "`cd $(roslispdir); pwd -W 2>/dev/null`" >> $@.tmp
 	cmp -s $@.tmp $@||cp $@.tmp $@
 	rm -f $@.tmp
 	cat $@

--- a/src/util.c
+++ b/src/util.c
@@ -191,9 +191,9 @@ char* uname_m(void) {
   }
   return substitute_char('-','_',p2);
 #else
-#if _WIN64
+#if defined(_WIN64)
   return q("x86-64");
-#elif _WIN32
+#elif defined(_WIN32)
   BOOL isWow64 = FALSE;
   LPFN_ISWOW64PROCESS fnIsWow64Process  = (LPFN_ISWOW64PROCESS)
     GetProcAddress(GetModuleHandle(TEXT("kernel32")),"IsWow64Process");


### PR DESCRIPTION
1. fix if _WIN32/_WIN64
2. fix script for generating gend.h

```
printf "#define ROS_COMPILE_ENVIRONMENT \"%s\"\n" "`gcc --version|head -n 1`" > gend.h.tmp
(printf "#define ROS_REVISION \"" && ((which git>/dev/null&&[ -e ../.git ]&& \
(git log -n 1 --oneline|cut -d' ' -f1| tr -d '\n'| tr -d '\r'))||printf "") && printf "\"\n") >> gend.h.tmp
(sh -c 'cd /usr/local/share/common-lisp/source/roswell; pwd -W' 2>&1 >/dev/null && (printf "#define WIN_LISP_PATH \"" \
echo `sh -c 'cd /usr/local/share/common-lisp/source/roswell; pwd -W 2>/dev/null'`| tr -d '\n'| tr -d '\r' |\
sed /\//\\/ \
printf "\\\\\"\n")  >> gend.h.tmp) || printf ""
sed: -e expression #1, char 3: unknown command: `/'
cmp -s gend.h.tmp gend.h||cp gend.h.tmp gend.h
rm -f gend.h.tmp
cat gend.h
#define ROS_COMPILE_ENVIRONMENT "gcc (GCC) 4.9.2"
#define ROS_REVISION "a68a105"

```