### PR TITLE
Muting the backtrace when invoking emacs (and fails)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -35,7 +35,7 @@ roswell (0.0.5.60-1) unstable; urgency=low
 roswell (0.0.5.59-1) unstable; urgency=low
 
   * Fix:Error when 'ros delete IMPL'.
-  * Change: separate Windos specific function from blabla.c to blabla_windows.c
+  * Change: separate Windows specific function from blabla.c to blabla_windows.c
 
  -- SANO Masatoshi <snmsts@gmail.com>  Mon, 18 Apr 2016 03:28:03 +0900
 

--- a/lisp/emacs.ros
+++ b/lisp/emacs.ros
@@ -14,6 +14,8 @@ exec ros -L sbcl-bin -- $0 "$@"
   (let ((path (merge-pathnames "slime-helper.el" (ros:opt "quicklisp"))))
     (unless (probe-file path)
       (ros:roswell '("-L" "sbcl-bin" "-s" "quicklisp-slime-helper" "-q") :interactive nil))
-    (ros:exec `("emacs" "-l" ,(namestring path) "--eval" "(setq inferior-lisp-program \"ros -Q run\")"
-                        ,@(cddr argv)))))
+    ;; TODO ignore-errors only when backtraces are not "activated".
+    (ignore-errors
+      (ros:exec `("emacs" "-l" ,(namestring path) "--eval" "(setq inferior-lisp-program \"ros -Q run\")"
+			  ,@(cddr argv))))))
 ;;; vim: set ft=lisp lisp:


### PR DESCRIPTION
See issue first point of roswell/roswell#151.