### PR TITLE
Better UX for commands `emacs` and `template`

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ Checkout [issues list](https://github.com/roswell/roswell/issues) if you are int
 
 See our [github wiki](https://github.com/roswell/roswell/wiki).
 We provide prebuilt binaries for homebrew on OSX, AUR on Arch and **also on Windows**.
+* [Linux (arch)](https://github.com/roswell/roswell/wiki/1.-Installation#linux)
+* [Mac OS X (brew)](https://github.com/roswell/roswell/wiki/1.-Installation#mac-os-x--homebrew-----use-the-custom-tap)
+* [Windows](https://github.com/roswell/roswell/wiki/1.-Installation#windows)
+* [Building from Source](https://github.com/roswell/roswell/wiki/1.-Installation#building-from-source)
 
 ## Features
 

--- a/lisp/emacs.ros
+++ b/lisp/emacs.ros
@@ -10,12 +10,27 @@ exec ros -L sbcl-bin -- $0 "$@"
   (:use :cl))
 (in-package :ros.script.emacs.3672012160)
 
+(defvar *verbose-p* (string= "1" (ros:opt "verbose")))
+
+(defmacro mute-error-if-not-verbose (&body body)
+  "Execute the body, catches (and hide) any error if *verbose-p* is nil."
+  `(handler-case
+       ,@body
+     (error (condition)
+       (if *verbose-p*
+	   (error condition)
+	   (values nil condition)))))
+
 (defun main (&rest argv)
   (let ((path (merge-pathnames "slime-helper.el" (ros:opt "quicklisp"))))
     (unless (probe-file path)
       (ros:roswell '("-L" "sbcl-bin" "-s" "quicklisp-slime-helper" "-q") :interactive nil))
-    ;; TODO ignore-errors only when backtraces are not "activated".
-    (ignore-errors
-      (ros:exec `("emacs" "-l" ,(namestring path) "--eval" "(setq inferior-lisp-program \"ros -Q run\")"
-			  ,@(cddr argv))))))
+    ;; This enable to set verbosity only for this file (instead of whole roswell).
+    (when (and (= 3 (length argv))
+	       (string= "--verbose" (third argv)))
+      (setf *verbose-p* t))    
+    (mute-error-if-not-verbose
+     (ros:exec
+	 `("emacs" "-l" ,(namestring path) "--eval"
+		   "(setq inferior-lisp-program \"ros -Q run\")" ,@(cddr argv))))))
 ;;; vim: set ft=lisp lisp:

--- a/lisp/template.ros
+++ b/lisp/template.ros
@@ -11,30 +11,57 @@ exec ros -Q -m roswell -L sbcl-bin -- $0 "$@"
   (:use :cl :ros.util))
 (in-package :ros.script.template.3670908195)
 
-(defvar *sub* '(("rm" . template-rm)
-                ("delete" . template-rm)
-                ("install" . template-install)
-                ("list" . template-list)))
+(defvar *subcommands* '(("rm" . template-rm)
+			("delete" . template-rm)
+			("install" . template-install)
+			("list" . template-list)
+			("help" . help)))
 
 (defvar *repositries* '(github)) ;; github should be the choice in 2016...
 
+(defun usage ()
+  (format *error-output*
+	  "~&***WIP*** Usage: ~A ~{~A~^/~} ~%"
+	  (ros:opt "wargv0")
+	  (mapcar #'car *subcommands*)))
+
+(defun help (_)
+  (declare (ignore _))
+  "Print usage and subcommands description"
+  (usage)
+  (loop
+     for (command . func) in *subcommands*
+     do
+       (format *error-output* "~&~15A ~A" command (documentation func 'function))))
+
+
 (defun main (method command &optional sub &rest argv)
   (declare (ignorable method command))
-  (let ((func (cdr (assoc sub *sub* :test #'equal))))
-    (when func (funcall func argv))))
+  (let ((func (cdr (assoc sub *subcommands* :test #'equal))))
+    (if func
+	(funcall func argv)
+	(usage))))
 
 (defun template-install (name)
-  (loop for i in *repositries*
-        until (apply i name)))
+  "Install (clone) a new template from github repository."
+  (loop
+     for i in *repositries*
+     until (apply i name)))
 
 (defun template-rm (name)
+  "Remove (delete) a template."
   (uiop/filesystem:delete-directory-tree
    (merge-pathnames (format nil "~A/~A/" "templates" name) (homedir))))
 
 (defun template-list (name)
+  "List the installed templates"
   (declare (ignore name))
-  (loop for x in (directory (merge-pathnames "templates/*/*/" (homedir)))
-        do (format t "~{~A~^/~}~%" (last (pathname-directory x) 2))))
+  (let* ((wildcard (merge-pathnames "templates/*/*/" (homedir)))
+	 (templates (directory wildcard)))
+    (unless templates
+      (format *error-output* "~&No template found in ~S." wildcard))
+    (loop for x in templates
+       do (format t "~{~A~^/~}~%" (last (pathname-directory x) 2)))))
 
 (defun github (name &rest argv)
   (declare (ignorable argv))


### PR DESCRIPTION
I tweaked the output of `ros emacs` and `ros template` accordingly to what I noted in #151.


For `ros emacs`, I added the `--verbose` flag.
```sh
m_psy@DESKTOP-VBK1ESA MINGW64 ~/Desktop/ros
$ ros emacs
'emacs' is not recognized as an internal or external command,
operable program or batch file.
```

```sh
m_psy@DESKTOP-VBK1ESA MINGW64 ~/Desktop/ros
$ ros --verbose emacs
opt:verbose:1
proccmd:emacs
proccmd:C:\bin\roswell\lisp\emacs.ros
frontend:script_*:argc=3 argv[0]=C:\bin\roswell\lisp\emacs.ros
ros_script_cmd=exec ros -L sbcl-bin -- $0 "$@"
proccmd:-L
proccmd:--
get_opt(program,0)=(null)
script_:argc=4 argv[0]=--
current=(null)
get_opt(lisp,1)=sbcl-bin
determin_impl:sbcl-bin
get_opt(sbcl-bin.version,1)=1.3.6
get_opt(asdf.version,0)=(null)
get_opt(program,0)=(null)
get_opt(program,0)=(null)
get_opt(impl,0)=sbcl-bin/1.3.6
get_opt(help,0)=(null)
get_opt(script,0)="C:\\bin\\roswell\\lisp\\emacs.ros""main""emacs"
get_opt(image,0)=(null)
get_opt(program,0)=(null)
get_opt(dynamic-space-size,0)=(null)
get_opt(control-stack-size,0)=(null)
get_opt(version,0)=(null)

help=nil script="C:\\bin\\roswell\\lisp\\emacs.ros""main""emacs"
get_opt(wrap,1)=(null)
args C:\Users\m_psy\.roswell\impls\x86-64\windows\sbcl-bin\1.3.6\bin\sbcl.exe --core C:\Users\m_psy\.roswell\impls\x86-64\windows\sbcl-bin\1.3.6\lib\sbcl\sbcl.core --noinform --no-sysinit --no-userinit --disable-debugger --eval (progn #-ros.init(cl:load "C:\\bin\\roswell\\lisp\\init.lisp")) --eval (ros:quicklisp) --eval (ros:run '((:script "C:\\bin\\roswell\\lisp\\emacs.ros""main""emacs")(:quit ())))
ROS_OPTS (("verbose""1")("homedir""C:\\Users\\m_psy\\.roswell\\")("wargv0""C:\\bin\\roswell\\ros.exe")("argv0""C:\\bin\\roswell\\ros.exe")("quicklisp""C:\\\\Users\\\\m_psy\\\\.roswell\\\\lisp\\\\quicklisp\\\\")("impl""sbcl-bin/1.3.6")("script""\"C:\\\\bin\\\\roswell\\\\lisp\\\\emacs.ros\"\"main\"\"emacs\"")("lisp""sbcl-bin")("swank.version""2.18")("sbcl-bin.version""1.3.6")("default.lisp""sbcl-bin"))
System:'C:\Users\m_psy\.roswell\impls\x86-64\windows\sbcl-bin\1.3.6\bin\sbcl.exe "--core" "C:\\Users\\m_psy\\.roswell\\impls\\x86-64\\windows\\sbcl-bin\\1.3.6\\lib\\sbcl\\sbcl.core" "--noinform" "--no-sysinit" "--no-userinit" "--disable-debugger" "--eval" "(progn #-ros.init(cl:load \"C:\\\\bin\\\\roswell\\\\lisp\\\\init.lisp\"))" "--eval" "(ros:quicklisp)" "--eval" "(ros:run '((:script \"C:\\\\bin\\\\roswell\\\\lisp\\\\emacs.ros\"\"main\"\"emacs\")(:quit ())))"'
'emacs' is not recognized as an internal or external command,
operable program or batch file.
Unhandled UIOP/RUN-PROGRAM:SUBPROCESS-ERROR in thread #<SB-THREAD:THREAD "main thread" RUNNING
                                                         {1002995BA3}>:
  Subprocess (:PROCESS #<SB-IMPL::PROCESS :EXITED 1>)
 with command "emacs -l C:/Users/m_psy/.roswell/lisp/quicklisp/slime-helper.el --eval (setq inferior-lisp-program \"ros -Q run\")"
 exited with error code 1

Backtrace for: #<SB-THREAD:THREAD "main thread" RUNNING {1002995BA3}>
0: (SB-DEBUG::DEBUGGER-DISABLED-HOOK #<UIOP/RUN-PROGRAM:SUBPROCESS-ERROR {1002F217B3}> #<unavailable argument>)
1: (SB-DEBUG::RUN-HOOK SB-EXT:*INVOKE-DEBUGGER-HOOK* #<UIOP/RUN-PROGRAM:SUBPROCESS-ERROR {1002F217B3}>)
2: (INVOKE-DEBUGGER #<UIOP/RUN-PROGRAM:SUBPROCESS-ERROR {1002F217B3}>)
3: (ERROR #<UIOP/RUN-PROGRAM:SUBPROCESS-ERROR {1002F217B3}>)
4: (MAIN "main" "emacs")
5: (SB-INT:SIMPLE-EVAL-IN-LEXENV (APPLY (QUOTE MAIN) ROS:*ARGV*) #<NULL-LEXENV>)
6: (SB-INT:SIMPLE-EVAL-IN-LEXENV (ROS:QUIT (APPLY (QUOTE MAIN) ROS:*ARGV*)) #<NULL-LEXENV>)
7: (SB-EXT:EVAL-TLF (ROS:QUIT (APPLY (QUOTE MAIN) ROS:*ARGV*)) NIL NIL)
8: ((LABELS SB-FASL::EVAL-FORM :IN SB-INT:LOAD-AS-SOURCE) (ROS:QUIT (APPLY (QUOTE MAIN) ROS:*ARGV*)) NIL)
9: (SB-INT:LOAD-AS-SOURCE #<CONCATENATED-STREAM :STREAMS NIL {1005B95C03}> :VERBOSE NIL :PRINT NIL :CONTEXT "loading")
10: ((FLET SB-FASL::LOAD-STREAM :IN LOAD) #<CONCATENATED-STREAM :STREAMS NIL {1005B95C03}> NIL)
11: (LOAD #<CONCATENATED-STREAM :STREAMS NIL {1005B95C03}> :VERBOSE NIL :PRINT NIL :IF-DOES-NOT-EXIST T :EXTERNAL-FORMAT :DEFAULT)
12: ((FLET ROS::BODY :IN ROS:SCRIPT) #<SB-SYS:FD-STREAM for "file C:\\bin\\roswell\\lisp\\emacs.ros" {1005B92D43}>)
13: (ROS:SCRIPT :SCRIPT "C:\\\\bin\\\\roswell\\\\lisp\\\\emacs.ros" "main" "emacs")
14: (ROS:RUN ((:SCRIPT "C:\\\\bin\\\\roswell\\\\lisp\\\\emacs.ros" "main" "emacs") (:QUIT NIL)))
15: (SB-INT:SIMPLE-EVAL-IN-LEXENV (ROS:RUN (QUOTE ((:SCRIPT "C:\\\\bin\\\\roswell\\\\lisp\\\\emacs.ros" "main" "emacs") (:QUIT NIL)))) #<NULL-LEXENV>)
16: (EVAL (ROS:RUN (QUOTE ((:SCRIPT "C:\\\\bin\\\\roswell\\\\lisp\\\\emacs.ros" "main" "emacs") (:QUIT NIL)))))
17: (SB-IMPL::PROCESS-EVAL/LOAD-OPTIONS ((:EVAL . "(progn #-ros.init(cl:load \"C:\\\\\\\\bin\\\\\\\\roswell\\\\\\\\lisp\\\\\\\\init.lisp\"))") (:EVAL . "(ros:quicklisp)") (:EVAL . "(ros:run '((:script \"C:\\\\\\\\bin\\\\\\\\roswell\\\\\\\\lisp\\\\\\\\emacs.ros\"\"main\"\"emacs\")(:quit ())))")))
18: (SB-IMPL::TOPLEVEL-INIT)
19: ((FLET #:WITHOUT-INTERRUPTS-BODY-82 :IN SB-EXT:SAVE-LISP-AND-DIE))
20: ((LABELS SB-IMPL::RESTART-LISP :IN SB-EXT:SAVE-LISP-AND-DIE))
21: ("foreign function: #x42E6FC")

unhandled condition in --disable-debugger mode, quitting
```

```sh
m_psy@DESKTOP-VBK1ESA MINGW64 ~/Desktop/ros
$ ros emacs --verbose
'emacs' is not recognized as an internal or external command,
operable program or batch file.
Unhandled UIOP/RUN-PROGRAM:SUBPROCESS-ERROR in thread #<SB-THREAD:THREAD "main thread" RUNNING
                                                         {1002995BD3}>:
  Subprocess (:PROCESS #<SB-IMPL::PROCESS :EXITED 1>)
 with command "emacs -l C:/Users/m_psy/.roswell/lisp/quicklisp/slime-helper.el --eval (setq inferior-lisp-program \"ros -Q run\") --verbose"
 exited with error code 1

Backtrace for: #<SB-THREAD:THREAD "main thread" RUNNING {1002995BD3}>
0: (SB-DEBUG::DEBUGGER-DISABLED-HOOK #<UIOP/RUN-PROGRAM:SUBPROCESS-ERROR {1002F23DB3}> #<unavailable argument>)
1: (SB-DEBUG::RUN-HOOK SB-EXT:*INVOKE-DEBUGGER-HOOK* #<UIOP/RUN-PROGRAM:SUBPROCESS-ERROR {1002F23DB3}>)
2: (INVOKE-DEBUGGER #<UIOP/RUN-PROGRAM:SUBPROCESS-ERROR {1002F23DB3}>)
3: (ERROR #<UIOP/RUN-PROGRAM:SUBPROCESS-ERROR {1002F23DB3}>)
4: (MAIN "main" "emacs" "--verbose")
5: (SB-INT:SIMPLE-EVAL-IN-LEXENV (APPLY (QUOTE MAIN) ROS:*ARGV*) #<NULL-LEXENV>)
6: (SB-INT:SIMPLE-EVAL-IN-LEXENV (ROS:QUIT (APPLY (QUOTE MAIN) ROS:*ARGV*)) #<NULL-LEXENV>)
7: (SB-EXT:EVAL-TLF (ROS:QUIT (APPLY (QUOTE MAIN) ROS:*ARGV*)) NIL NIL)
8: ((LABELS SB-FASL::EVAL-FORM :IN SB-INT:LOAD-AS-SOURCE) (ROS:QUIT (APPLY (QUOTE MAIN) ROS:*ARGV*)) NIL)
9: (SB-INT:LOAD-AS-SOURCE #<CONCATENATED-STREAM :STREAMS NIL {1005B9DC33}> :VERBOSE NIL :PRINT NIL :CONTEXT "loading")
10: ((FLET SB-FASL::LOAD-STREAM :IN LOAD) #<CONCATENATED-STREAM :STREAMS NIL {1005B9DC33}> NIL)
11: (LOAD #<CONCATENATED-STREAM :STREAMS NIL {1005B9DC33}> :VERBOSE NIL :PRINT NIL :IF-DOES-NOT-EXIST T :EXTERNAL-FORMAT :DEFAULT)
12: ((FLET ROS::BODY :IN ROS:SCRIPT) #<SB-SYS:FD-STREAM for "file C:\\bin\\roswell\\lisp\\emacs.ros" {1005B9AD73}>)
13: (ROS:SCRIPT :SCRIPT "C:\\\\bin\\\\roswell\\\\lisp\\\\emacs.ros" "main" "emacs" "--verbose")
14: (ROS:RUN ((:SCRIPT "C:\\\\bin\\\\roswell\\\\lisp\\\\emacs.ros" "main" "emacs" "--verbose") (:QUIT NIL)))
15: (SB-INT:SIMPLE-EVAL-IN-LEXENV (ROS:RUN (QUOTE ((:SCRIPT "C:\\\\bin\\\\roswell\\\\lisp\\\\emacs.ros" "main" "emacs" "--verbose") (:QUIT NIL)))) #<NULL-LEXENV>)
16: (EVAL (ROS:RUN (QUOTE ((:SCRIPT "C:\\\\bin\\\\roswell\\\\lisp\\\\emacs.ros" "main" "emacs" "--verbose") (:QUIT NIL)))))
17: (SB-IMPL::PROCESS-EVAL/LOAD-OPTIONS ((:EVAL . "(progn #-ros.init(cl:load \"C:\\\\\\\\bin\\\\\\\\roswell\\\\\\\\lisp\\\\\\\\init.lisp\"))") (:EVAL . "(ros:quicklisp)") (:EVAL . "(ros:run '((:script \"C:\\\\\\\\bin\\\\\\\\roswell\\\\\\\\lisp\\\\\\\\emacs.ros\"\"main\"\"emacs\"\"--verbose\")(:quit ())))")))
18: (SB-IMPL::TOPLEVEL-INIT)
19: ((FLET #:WITHOUT-INTERRUPTS-BODY-82 :IN SB-EXT:SAVE-LISP-AND-DIE))
20: ((LABELS SB-IMPL::RESTART-LISP :IN SB-EXT:SAVE-LISP-AND-DIE))
21: ("foreign function: #x42E6FC")

unhandled condition in --disable-debugger mode, quitting
```





And for `ros template`, I added some explanation (adding `usage` and `help` functions).
```sh
m_psy@DESKTOP-VBK1ESA MINGW64 ~/Desktop/ros
$ ros template
***WIP*** Usage: C:\bin\roswell\ros.exe rm/delete/install/list/help
```

```sh
m_psy@DESKTOP-VBK1ESA MINGW64 ~/Desktop/ros
$ ros template help
***WIP*** Usage: C:\bin\roswell\ros.exe rm/delete/install/list/help
rm              Remove (delete) a template.
delete          Remove (delete) a template.
install         Install (clone) a new template from github repository.
list            List the installed templates
help            Print usage and subcommands description
```