### PR TITLE
Link README to roswell wiki on CI integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ We provide prebuilt binaries for homebrew on OSX, AUR on Arch and **also on Wind
 * **Novel** : Better integration to the command-line interface (Bash completion, etc)
 * **Novel** : Infrastructure for bundling/installing the scripts to/from a quicklisp system
 * **Novel** : Better support for Windows environment (tested exhaustively)
-* **Novel** : Better integration to CI environment (e.g. Travis-CI, CircleCI, Coverall)
+* **Novel** : Better integration to CI environment (e.g. [Travis-CI](https://github.com/roswell/roswell/wiki/4.1-Travis-CI), [CircleCI](https://github.com/roswell/roswell/wiki/4.2-Circle-CI), [Coveralls](https://github.com/roswell/roswell/wiki/4.3-Coverall))
 
 ## Usage
 


### PR DESCRIPTION
Add links to how to set up Travis, CircleCI and Coveralls.

This should make it easier to find the appropriate documentation from the project's front page, and even likely avoid issues like #173