### PR TITLE
Install libc6-i386 on allegro and improve CI script

### DIFF
--- a/scripts/install-for-ci.sh
+++ b/scripts/install-for-ci.sh
@@ -126,7 +126,8 @@ log "ros --version"
 log "ros setup"
 
 case "$LISP" in
-    alisp)
+    alisp|allegro)
+	apt_unless_installed libc6-i386
         LISP=allegro
         ;;
     cmu|cmucl)

--- a/scripts/install-for-ci.sh
+++ b/scripts/install-for-ci.sh
@@ -1,5 +1,4 @@
 #!/bin/sh
-fetch
 set -e
 
 ROSWELL_TARBALL_PATH=$HOME/roswell.tar.gz


### PR DESCRIPTION
* CI script now detects if we are building on Travis and changes default ROSWELL_INSTALL_DIR to a directory in the user path (to be able to run with `sudo:false`). If a ROSWELL_INSTALL_DIR was provided no further configuration is performed, to preserve backwards-compatibility.

* CI script will now install libc6-i386 when requesting allegro or alisp to be built

* Removed the initial "fetch" instruction