### PR TITLE
Fix segmentation fault caused by a missing option argument.

### DIFF
--- a/src/proc-opt.c
+++ b/src/proc-opt.c
@@ -25,6 +25,8 @@ LVal proc_options(LVal arg,struct proc_opt *popt) {
       struct sub_command* fp=firstp(p);
       if(strcmp(&arg0[2],fp->name)==0) {
         int result= fp->call(arg,fp);
+        if(result<0)
+          return dispatch(stringlist("help",NULL),&top);
         if(fp->terminating) {
           cond_printf(1,"terminating:%s\n",arg0);
           exit(result);
@@ -40,6 +42,8 @@ LVal proc_options(LVal arg,struct proc_opt *popt) {
         struct sub_command* fp=firstp(p);
         if(fp->short_name&&strcmp(arg0,fp->short_name)==0) {
           int result= fp->call(arg,fp);
+          if(result<0)
+            return dispatch(stringlist("help",NULL),&top);
           if(fp->terminating) {
             cond_printf(1,"terminating:%s\n",arg0);
             exit(result);

--- a/src/register-commands.c
+++ b/src/register-commands.c
@@ -30,9 +30,11 @@ DEF_SUBCMD(opt_program0) {
 DEF_SUBCMD(opt_take1) {
   int argc=length(arg_);
   const char* arg=cmd->name;
-  if(arg && argc>1)
+  if(arg && argc>1) {
     set_opt(&local_opt,arg,firsts(nthcdr(1,arg_)));
-  return 2;
+    return 2;
+  }
+  return -1;
 }
 
 #define OPT_APPEND(sym)                                    \
@@ -46,8 +48,9 @@ DEF_SUBCMD(opt_take1) {
                     escape_string(firsts(nthcdr(1,arg_))), \
                     q("\")"),NULL);                        \
       set_opt(&local_opt,#sym,current);                    \
+      return 2;                                            \
     }                                                      \
-    return 2;                                              \
+    return -1;                                             \
   }
 
 OPT_APPEND(program)


### PR DESCRIPTION
Segmentation fault has occurred when no argument is given to options as a parameter.
This patch adds some checks and prints help messages if arguments are missing.