### PR TITLE
Use compression when building executable with SBCL.

### DIFF
--- a/lisp/dump-sbcl.lisp
+++ b/lisp/dump-sbcl.lisp
@@ -11,6 +11,7 @@
    ;; however, this only affects old cheyneyGC
    ;; http://www.sbcl.org/manual/#Efficiency-Hacks
    :purify t ; just here to make it explicit
+   :compression t ; we all want our programs to be small, right?
    :toplevel
    #'(lambda ()
        (setf *load-pathname* (pathname (first sb-ext:*posix-argv*)))

--- a/lisp/dump-sbcl.lisp
+++ b/lisp/dump-sbcl.lisp
@@ -11,7 +11,9 @@
    ;; however, this only affects old cheyneyGC
    ;; http://www.sbcl.org/manual/#Efficiency-Hacks
    :purify t ; just here to make it explicit
-   :compression t ; we all want our programs to be small, right?
+   ; we all want our programs to be small, right?
+   #+sb-core-compression :compression
+   #+sb-core-compression t
    :toplevel
    #'(lambda ()
        (setf *load-pathname* (pathname (first sb-ext:*posix-argv*)))


### PR DESCRIPTION
With this one line patch, I've got 16M binary instead of 83.