### PR TITLE
File lisp/util-run.lisp was removed in fbcdbf5454e91fffa5b83f1a0c77cb3a803c50bb but not from roswell.asd

### DIFF
--- a/roswell.asd
+++ b/roswell.asd
@@ -40,7 +40,6 @@ roswell does not function without help of C codes.
                  (:file "locations" :depends-on ("util"))
                  (:file "util-swank" :depends-on ("util"))
                  (:file "util" :depends-on ("init"))
-                 (:file "util-run" :depends-on ("init"))
                  (:file "init"))))
   :description "a command line tool to install and manage Common Lisp implementations damn easily."
   :long-description


### PR DESCRIPTION
This patch fixes the issue of loading roswell as a system into a lisp interpreter.