### PR TITLE
Better documentation for ros install.

### DIFF
--- a/lisp/help-install.lisp
+++ b/lisp/help-install.lisp
@@ -8,11 +8,32 @@
   (if (not (second argv))
       (let ((s *error-output*)
             (cmd (pathname-name (opt "wargv0"))))
-        (format s "Usage:~%~%   ~A install impl [options]~%or~%" cmd)
-        (format s "   ~A install repository [repository... ] ~%~%" cmd)
-        (format s "For more details on impl specific options, type:~%")
-        (format s "   ~A help install impl~2%" cmd)
-        (format s "Candidates impls for installation are:~%")
+        (flet ((usage (msg)
+                 (if (search "~A" msg)
+                     (format s msg cmd)
+                     (format s msg))
+                 (terpri s)))
+          
+          (mapcar #'usage
+                  '("Usage:"
+                    ""
+                    "To install a new Lisp implementaion:"
+                    "   ~A install impl [options]"
+                    "or a system from the GitHub:"
+                    "   ~A install fukamachi/prove/v2.0.0 [repository... ]"
+                    "or an asdf system from quicklisp:"
+                    "   ~A install quicklisp-system [system... ]"
+                    "or a local script:"
+                    "   ~A install ./some/path/to/script.ros [path... ]"
+                    "or a local system:"
+                    "   ~A install ./some/path/to/system.asd [path... ]"
+                    ""
+                    "For more details on impl specific options, type:"
+                    "   ~A help install impl"
+                    ""
+                    ""
+                    "Candidates impls for installation are:")))
+        
         (loop for i in (asdf:registered-systems)
               with len = #.(length "roswell.install.")
               when (and (string-equal "roswell.install." i :end2 (min (length i) len))

--- a/lisp/util-install.lisp
+++ b/lisp/util-install.lisp
@@ -77,6 +77,38 @@
   (clone-github impl version :path "local-projects" :branch tag))
 
 (defun install (argv)
+  "Install an implementation or a system.
+
+   How this function parses it's arguments.
+
+   It takes each argument and makes following:
+
+   1. Splits the argument by first '/' occurence.
+   2. Everything before / becomes the name of an implementation or a system.
+   3. Everything after / (if any), again splitted by '/'.
+   4. If step 3 was successful, first part of the string becomes a 'version'
+      and second part (if any) becomes a 'tag'.
+
+   After the parsing, roswell sequentially tries:
+
+   1. To install 'implementation' of the given 'version'.
+   2. To install a something.ros script, if argument is a path to a file.
+   3. To install an asdf system with same name as exact argument's value.
+   4. To install a system by local path.
+      Path should start with '.', contain at least one '/' and point
+      to an asd file.
+      System is installed into \"${roswell-homedir}/local-projects/local/${system-name}/\".
+   5. If nothing of above matched, it tries to clone system from the github,
+      like:
+      git clone -b 'tag' 'system'/'version'
+
+      For example, if you did: ros install some/repo/the-feature, it will do
+
+      git clone -b the-feature \\
+          https://github.com/some/repo \\
+          ${roswell-home}/local-projects/some/repo
+      
+ "
   (read-call "quicklisp-client:register-local-projects")
   (loop
     with *ros-path* = (make-pathname :defaults (opt "argv0"))


### PR DESCRIPTION
Now it prints help like that:
```
Usage:

To install a new Lisp implementaion:
   ros install impl [options]
or a system from the GitHub:
   ros install fukamachi/prove/v2.0.0 [repository... ]
or an asdf system from quicklisp:
   ros install quicklisp-system [system... ]
or a local script:
   ros install ./some/path/to/script.ros [path... ]
or a local system:
   ros install ./some/path/to/system.asd [path... ]
...
```

Also, an `install` function now has nice docstring.