### PR TITLE
Specify :output :interactive for ros:exec.

### DIFF
--- a/lisp/init.lisp
+++ b/lisp/init.lisp
@@ -152,7 +152,7 @@ have the latest asdf, and this file has a workaround for this.
   #+(and unix ccl)
   (ignore-errors
     (ccl:with-string-vector (argv args) (ccl::%execvp argv)))
-  (quit (run-program args)))
+  (quit (run-program args :output :interactive)))
 
 (defun quicklisp (&key path (environment "QUICKLISP_HOME"))
   (unless (find :quicklisp *features*)


### PR DESCRIPTION
Unless the :output will be NIL and the command will return immediately even though the command would block.
For instance, `qlot exec ros run` returns immediately without any errors.