### PR TITLE
Support for initial proxy setup

### DIFF
--- a/lisp/install-quicklisp.lisp
+++ b/lisp/install-quicklisp.lisp
@@ -65,6 +65,7 @@
        (let ((*standard-output* (make-broadcast-stream)))
          (funcall (intern (string :install) (find-package :quicklisp-quickstart))
                   :path path
+                  :proxy (opt "quicklisp.proxy")
                   :client-url (opt "quicklisp.client")
                   :dist-url (opt "quicklisp.dist"))))))
   (cons t argv))


### PR DESCRIPTION
Quicklisp supports setting :proxy during installation, this flag will be persisted and used for subsequent calls to ql: functions. See more http://netprophetblog.blogspot.co.uk/2014/02/tool-posting-quicklisp-with.html