### PR TITLE
fixed message when implementation was not installed

### DIFF
--- a/src/cmd-run.c
+++ b/src/cmd-run.c
@@ -178,7 +178,9 @@ DEF_SUBCMD(cmd_run_star) {
   }
   s(opts);
   if(arg)
-    cond_printf(0,exist?"%s is not executable.Missing 32bit glibc?\n":"%s is not exist.stop.\n",arg[0]);
+    exist?
+      cond_printf(0,"%s is not executable.Missing 32bit glibc?\n",arg[0]):
+      cond_printf(0,"%s is not exist.stop.\n",get_opt("impl",0));
   return 1;
 }
 


### PR DESCRIPTION
after
```
$ ./ros -L sbcl run
sbcl/system is not exist.stop.
```

before
```
$ ros -L sbcl run
 is not exist.stop.
```