### PR TITLE
Added support for i386 architecture

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -19,6 +19,10 @@ char* uname_m(void) {
     s(p2);
     return q("x86");
   }
+  if(strcmp(p2,"i386")==0) {
+    s(p2);
+    return q("x86");
+  }
   if(strcmp(p2,"amd64")==0) {
     s(p2);
     return q("x86-64");


### PR DESCRIPTION
Attempting to run `ros setup` under freebsd-i386 resulted in the following:
```
No SBCL version specified. Downloading platform-table.html to see the available versions...
[##########################################################################]100%
this architecture is not supported.stop
[1]    32198 segmentation fault (core dumped)  ros setup
```
Since i386 is supported and a member of the x86 processor family I added it to _uname_m_.