### PR TITLE
Don't swallow exit code on Windows

### DIFF
--- a/src/util-system_windows.c
+++ b/src/util-system_windows.c
@@ -106,8 +106,8 @@ int System(const char* command) {
   DWORD r=WaitForSingleObject(pi.hProcess, INFINITE);
   if(WAIT_OBJECT_0!=r)
     return 1;
-  if(!GetExitCodeProcess(pi.hProcess,&ExitCode)||ExitCode)
-    return ExitCode||1;
+  if(GetExitCodeProcess(pi.hProcess,&ExitCode))
+    return ExitCode;
   return 0;
 }
 


### PR DESCRIPTION
On Windows, roswell will turn all non-zero exit codes from commands into 1.
This is not the behavior observed on Linux, and it's not very helpful, so I assume it's a bug.

This is a quick fix that just returns the processes' real exit code.