### PR TITLE
modify install+7zip.lisp

### DIFF
--- a/lisp/install+7zip.lisp
+++ b/lisp/install+7zip.lisp
@@ -32,7 +32,7 @@
           (format t "7zip already setup~%")
           (progn
             (format t "archive=~A extract ~A~%" archive (7za-uri))
-            #-win32(download (7za-uri) (ensure-directories-exist archive))
+            (download (7za-uri) (ensure-directories-exist archive))
             (unzip archive (ensure-directories-exist prefix)))))
     (cons t argv)))
 


### PR DESCRIPTION
Issue 番号#288を直しました。
I fixed Issue # 288.

'install+7zip.lisp'中の#-windowsを削除しましたが問題ないでしょうか？
I deleted # -windows in 'install+7zip.lisp', but is there a problem?