### PR TITLE
Add "ros template deinit" subcommand to remove template

### DIFF
--- a/documents/ros-template.md
+++ b/documents/ros-template.md
@@ -10,6 +10,10 @@ init template-name
 
   : Create new template in local-project directory.
 
+deinit template-name
+
+  : Remove a template from local-project directory.
+
 list
 
   : Show file list and states of the files *type* *chmod* *rewrite* in templates.

--- a/lisp/template.ros
+++ b/lisp/template.ros
@@ -11,6 +11,7 @@ exec ros -Q -m roswell -N roswell -- $0 "$@"
 (in-package :ros.script.template.3670908195)
 
 (defvar *subcommands*  '(("init"  . template-init)
+                         ("deinit" . template-deinit)
                          ("list" . template-list)
                          ("checkout" . template-checkout)
                          ("add" . template-add)
@@ -30,6 +31,23 @@ exec ros -Q -m roswell -N roswell -- $0 "$@"
       (format *error-output* "already exist ~A~%" path)
       (ros:quit 0))
     (template-create name)))
+
+(defun template-deinit (names)
+  "Remove a template"
+  (let* ((name (first names))
+         (path (template-asd-path name)))
+    (unless name
+      (format *error-output* "template name is required.~%")
+      (ros:quit 1))
+    (when (equal name "default")
+      (format *error-output* "can't remove \"default\".~%")
+      (ros:quit 1))
+    (unless (probe-file path)
+      (format *error-output* "template: ~S not found.~%" name)
+      (ros:quit 1))
+    (template-remove name)
+    (when (equal (template-default) name)
+      (setf (template-default) "default"))))
 
 (defun template-list (_)
   "List the installed templates"

--- a/lisp/util-template.lisp
+++ b/lisp/util-template.lisp
@@ -14,6 +14,7 @@
 
    :templates-list
    :template-create
+   :template-remove
    :template-directory
    :template-remove-file
    :template-add-file
@@ -186,6 +187,13 @@
 
 (defun template-create (name)
   (template-write (sanitize name) nil))
+
+(defun template-remove (name)
+  (uiop:delete-directory-tree
+   (template-path name)
+   :validate (lambda (path)
+               (equal (car (last (pathname-directory path)))
+                      name))))
 
 (defun template-directory (name)
   (getf (template-read (sanitize name)) :files))


### PR DESCRIPTION
It seems to me that there is no method to remove a template itself.
So I added a sub-command "deinit" to "ros template".