### PR TITLE
Fix wrong display template name with hyphen

### DIFF
--- a/lisp/util-template.lisp
+++ b/lisp/util-template.lisp
@@ -81,10 +81,9 @@
     (cond
       (name
        (mapcar (lambda (x)
-                 (subseq (pathname-name x)
-                         (1+ (position-if
-                              (lambda (x) (find x ".-"))
-                              (pathname-name x) :from-end t))))
+                 (cond
+                   ((equal (pathname-name x) "init-default") "default")
+                   (t (subseq (pathname-name x) 13))))
                *))
       (t *))))
 


### PR DESCRIPTION
This is a patch to fix the following problem.

When "ros template checkout" sub-command with no argument shows existing template names, a name with hyphen is wrongly displayed. For example, "some-template-name" is displayed as "name".

About implementation. because I couldn't find smarter way to process both "init-default" (that should be displayed as "default") and "roswell.init.xxxx" (that should be displayed as "xxxx"), I simply split the process.