### PR TITLE
Add "export" and "import" sub-commands to "ros template"

### DIFF
--- a/documents/ros-template.md
+++ b/documents/ros-template.md
@@ -46,6 +46,10 @@ rewrite [template-name] file rewrite-rule
 
   : Change file name using djula template.Variables {{name}} {{author}} {{email}} {{universal_time}} are available for rewrite-rule.
 
+export [template-name] [directory]
+
+  : Export files in current template to current directory.
+
 help
 
   : Show the subcommand help.

--- a/documents/ros-template.md
+++ b/documents/ros-template.md
@@ -50,6 +50,10 @@ export [template-name] [directory]
 
   : Export files in current template to current directory.
 
+import [directory]
+
+  : Import template in current directory
+
 help
 
   : Show the subcommand help.

--- a/lisp/template.ros
+++ b/lisp/template.ros
@@ -22,6 +22,7 @@ exec ros -Q -m roswell -N roswell -- $0 "$@"
                          ("chmod" . template-chmod)
                          ("rewrite" . template-rewrite)
                          ("export" . template-export)
+                         ("import" . template-import)
                          ("help" . template-help)))
 
 (defun template-init (names)
@@ -165,6 +166,15 @@ exec ros -Q -m roswell -N roswell -- $0 "$@"
       (unless (string= dst "/" :start1 (1- (length dst)))
         (setf dst (format nil "~A/" dst))))
     (template-export-files name dst)))
+
+(defun template-import (_)
+  "Import template"
+  (let ((src "./"))
+    (when (first _)
+      (setf src (first _))
+      (unless (string= src "/" :start1 (1- (length src)))
+        (setf src (format nil "~A/" src))))
+    (template-import-files src)))
 
 (defun template-help (_)
   (declare (ignore _))

--- a/lisp/template.ros
+++ b/lisp/template.ros
@@ -21,6 +21,7 @@ exec ros -Q -m roswell -N roswell -- $0 "$@"
                          ("type" . template-type)
                          ("chmod" . template-chmod)
                          ("rewrite" . template-rewrite)
+                         ("export" . template-export)
                          ("help" . template-help)))
 
 (defun template-init (names)
@@ -148,6 +149,22 @@ exec ros -Q -m roswell -N roswell -- $0 "$@"
     (when (equal name "default")
       (setf name (pop _)))
     (template-attr-file name (first _) :rewrite (second _))))
+
+(defun template-export (_)
+  "Export template to directory"
+  (let ((name (template-default))
+        (dst "./"))
+    (when (and (equal name "default") (first _))
+      (setf name (pop _)))
+    (unless (and (templates-list :filter name)
+                 (not (equal name "default")))
+      (format *error-output* "template ~S can't be exported.~%" name)
+      (ros:quit 1))
+    (when (first _)
+      (setf dst (first _))
+      (unless (string= dst "/" :start1 (1- (length dst)))
+        (setf dst (format nil "~A/" dst))))
+    (template-export-files name dst)))
 
 (defun template-help (_)
   (declare (ignore _))

--- a/lisp/util-template.lisp
+++ b/lisp/util-template.lisp
@@ -20,6 +20,7 @@
    :template-add-file
    :template-attr-file
    :template-export-files
+   :template-import-files
 
    :template-apply
 
@@ -163,10 +164,10 @@
                   (asdf:load-system :roswell.util.template :verbose nil)
                   (funcall (read-from-string "roswell.util.template:template-apply") _ r *params*)))))))
 
-(defun template-read (name)
+(defun template-read-asd (asd-path)
   (let (package
         read/)
-    (with-open-file (o (template-asd-path name)
+    (with-open-file (o asd-path
                        :direction :input
                        :if-does-not-exist :error)
       (setq read/ (read o))
@@ -184,6 +185,9 @@
                    (string-equal  '*params* (second read/))) 
         (error "not init template ~S~%" (list read/)))
       (second (third read/)))))
+
+(defun template-read (name)
+  (template-read-asd (template-asd-path name)))
 
 (defun template-create (name)
   (template-write (sanitize name) nil))
@@ -251,3 +255,24 @@
             (template-directory template-name))
       (uiop:copy-file path
                       (merge-pathnames (format nil "~A.asd" (pathname-name path)) dst)))))
+
+(defun template-import-files (src)
+  (let ((asd-path (first (directory (merge-pathnames "roswell.init.*.asd" src)))))
+    (unless asd-path
+      (error "\"roswell.init.*.asd\" is not exist"))
+    (let ((name (subseq (pathname-name asd-path) 13)))
+      (when (templates-list :filter name)
+        (template-remove name))
+      (template-create name)
+      (uiop:with-current-directory (src)
+        (mapc (lambda (x)
+                (let ((file-name (getf x :name))
+                      (chmod (getf x :chmod))
+                      (rewrite (getf x :rewrite)))
+                  (template-add-file name file-name file-name)
+                  (template-attr-file name file-name :method (getf x :method))
+                  (when rewrite
+                    (template-attr-file name file-name :rewrite rewrite))
+                  (when chmod
+                    (template-attr-file name file-name :chmod chmod))))
+              (reverse (getf (template-read-asd asd-path) :files)))))))

--- a/lisp/util-template.lisp
+++ b/lisp/util-template.lisp
@@ -19,6 +19,7 @@
    :template-remove-file
    :template-add-file
    :template-attr-file
+   :template-export-files
 
    :template-apply
 
@@ -237,3 +238,16 @@
 
 #+ros.init
 (roswell.util:system "util-template")
+
+(defun template-export-files (template-name dst)
+  (let ((path (first (templates-list :filter template-name))))
+    (when (and path (equal (pathname-type path) "asd"))
+      (mapc (lambda (x)
+              (let* ((file-name (getf x :name))
+                     (dst-file-path (merge-pathnames file-name dst)))
+                (ensure-directories-exist dst-file-path)
+                (uiop:copy-file (template-file-path template-name file-name)
+                                dst-file-path)))
+            (template-directory template-name))
+      (uiop:copy-file path
+                      (merge-pathnames (format nil "~A.asd" (pathname-name path)) dst)))))


### PR DESCRIPTION
This is a proposal of "export" and "import" sub-commands for "ros template".

"ros template" has various sub-commands to edit template in local environment. However, it is difficult to cooporate with external environment (for example, to manage a template in Git (with not-encoded file names), or to distribute it to other developer). So I want to add the sub-commands to make it easy.

- "export" sub-command extracts "roswell.init.xxx.asd" and files in template to local directory.
- "import" sub-command adds (or replaces) template according to "roswell.init.xxx.asd" and files in local directory.