### PR TITLE
Update "ros template type" to enable to set default type

### DIFF
--- a/documents/ros-template.md
+++ b/documents/ros-template.md
@@ -36,7 +36,7 @@ rm [template-name] [files ...]
 
 type [template-name] [type] [files ...]
 
-  : Change file type. current choice for *type*s are *djula* or *copy* {{name}} {{author}} {{email}} {{universal_time}} are available variable in the template file.
+  : Change file type. current choice for *type*s are *djula* or *copy* {{name}} {{author}} {{email}} {{universal_time}} are available variable in the template file. Withoug files, change default type.
 
 chmod [template-name] [mode] [files ...] 
 

--- a/lisp/template.ros
+++ b/lisp/template.ros
@@ -141,12 +141,18 @@ exec ros -Q -m roswell -N roswell -- $0 "$@"
     (let ((type (first _))
           (sets (loop for i on *template-function-plist* by #'cddr
                       collect (string-downcase (first i)))))
+      (unless type
+        (let ((type (getf (template-parameter name) :default-method)))
+          (format t "current default type is \"~A\"~%" (if type type "copy")))
+        (ros:quit 0))
       (unless (find type sets
                     :test 'equal)
         (format *error-output* "should be one of~%~{~A~%~}" sets)
         (ros:quit 1))
-      (loop for i in (rest _)
-            do (template-attr-file name i :method type)))))
+      (if (rest _)
+          (loop for i in (rest _)
+                do (template-attr-file name i :method type))
+          (template-attr-common name :default-method type)))))
 
 (defun template-chmod (_)
   "Set mode for a file."


### PR DESCRIPTION
This is a proposal of default type in "ros template". "ros template" has 2 types, "copy" and "djula". But I think most of files in a template will be a same type in many cases. 

Usage:
When using "ros template type" sub-command without file names, it sets default type. The default type affects to newly added files. Please see the following example.

```bash
$ ros template type
current default type is "copy"
$ ros template add file1
$ ros template type djula
$ ros template type
current default type is "djula"
$ ros template add file2
$ ros template list
      djula file2
      copy  file1
```

Implementation:
I added ":common" parameter to achieve such template global parameter. In `roswell.ini.*.asd", it will be appeared as the following.

```lisp
# Note: I manually formatted for ease of viewing.
(DEFVAR *PARAMS*
  '(:COMMON (:DEFAULT-METHOD "djula")
    :FILES ((:NAME "file2" :METHOD "djula")
            (:NAME "file1" :METHOD "copy"))))
```