### PR TITLE
Fix search path for using template in "ros init"

### DIFF
--- a/lisp/init.ros
+++ b/lisp/init.ros
@@ -11,7 +11,12 @@ exec ros +A -Q -m roswell -N roswell -- $0 "$@"
 (in-package :ros.script.init.3672012201)
 
 (defun main (&rest r)
-  (module-main r :default "default")
+  (let ((ql:*local-project-directories*
+         (append (mapcar (lambda (path)
+                           (merge-pathnames "templates/" path))
+                         ql:*local-project-directories*)
+                 ql:*local-project-directories*)))
+    (module-main r :default "default"))
   ;; show usage ?
   )
 ;;; vim: set ft=lisp lisp:


### PR DESCRIPTION
I fixed search path of "ros init" to preferentially find templates under "templates/" directory under `ql:*local-project-directories*`.

Previously, "ros init" can find ".asd" of templates not under "templates/" at first. This behavior will cause loading wrong the ".asd" typically when exporting templates under `ql:*local-project-directories*`.