### PR TITLE
Fix search path in "ros template"

### DIFF
--- a/lisp/util-template.lisp
+++ b/lisp/util-template.lisp
@@ -69,7 +69,10 @@
            collect (code-char i)) 'string)))
 
 (defun templates-list (&key filter name)
-  (let* ((* (loop for x in (append *template-base-directories* (list (first ql:*local-project-directories*)))
+  (let* ((* (loop for x in (append *template-base-directories*
+                                   (mapcar (lambda (path)
+                                             (merge-pathnames "templates/" path))
+                                           ql:*local-project-directories*))
                   append (directory (merge-pathnames "**/*.asd" x))))
          (* (remove-if-not (lambda (x) (ignore-errors (string-equal "roswell.init." (pathname-name x) :end2 13))) *))
          (* (cons (merge-pathnames "init-default.lisp" (ros:opt "lispdir")) *))


### PR DESCRIPTION
This is similar issue to https://github.com/roswell/roswell/pull/304 in "ros template".

For example, using "ros template deinit" fails if it finds a wrong ".asd" file not in "templates/" directory. So I added "templates/" suffix to directories in `ql:*local-project-directories*`.

In addition, previously it searched only the first path of `ql:*local-project-directories*`. Then, this commit changes to search all paths in it. The first motivation was to avoid failure of search by "ros init" (because the first path will become ".../templates/templates/"). But it seems to me that there is no reason not to search remained paths.