### PR TITLE
Call setgroups before setuid.

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -119,6 +119,7 @@ void setup_uid(int euid_or_uid) {
            seteuid(uid)==0))
         cond_printf(0,"Error setegid/seteuid \n");
     }else {
+      setgroups(0, NULL);
       if(!(setgid(gid)==0 &&
            setuid(uid)==0))
         cond_printf(0,"Error setgid/setuid \n");

--- a/src/util.h
+++ b/src/util.h
@@ -16,6 +16,7 @@
 #ifndef HAVE_WINDOWS_H
 #include <pwd.h>
 #include <unistd.h>
+#include <grp.h>
 #include <signal.h>
 #include <dirent.h>
 #include <sys/types.h>


### PR DESCRIPTION
Found when creating a RPM package.

```
[   11s] RPMLINT report:                            
[   11s] ===============                            
[   12s] roswell.x86_64: W: missing-call-to-setgroups-before-setuid /usr/bin/ros                         
[   12s] This executable is calling setuid and setgid without setgroups or initgroups.                   
[   12s] There is a high probability this means it didn't relinquish all groups, and                     
[   12s] this would be a potential security issue to be fixed. Seek POS36-C on the web                   
[   12s] for details about the problem.             
[   12s]                                            
[   12s] 2 packages and 0 specfiles checked; 0 errors, 1 warnings.   
```

Full output can be viewed here: https://build.opensuse.org/package/live_build_log/home:bheesham/roswell/openSUSE_Leap_15.0/x86_64