### PR TITLE
fix segmentation fault that caused by failure on sbcl_bin_download

### DIFF
--- a/src/install-sbcl-bin.c
+++ b/src/install-sbcl-bin.c
@@ -80,6 +80,14 @@ int sbcl_bin_download(struct install_options* param) {
       if('1'<= param->version[len] && param->version[len] <= '9') {
         param->version[len]--;
         s(param->expand_path),s(impls_sbcl_bin.uri);
+      }else if('2' <= param->version[len-1] && param->version[len-1] <= '9') {
+        param->version[len-1]--;
+        param->version[len] = '9';
+        s(param->expand_path),s(impls_sbcl_bin.uri);
+      }else if('1' == param->version[len-1]) {
+        param->version[len-1] = '9';
+        param->version[len] = '\0';
+        s(param->expand_path),s(impls_sbcl_bin.uri);
       }else{
         s(arch),s(home);
         return 0;


### PR DESCRIPTION
`ros setup` can fail when the last group of digits in latest version of sbcl-bin has more than two digits .

Here is an example of this case.

```
$ uname -a
Darwin yuyanoMacBook-Pro.local 17.7.0 Darwin Kernel Version 17.7.0: Thu Jun 21 22:53:14 PDT 2018; root:xnu-4570.71.2~1/RELEASE_X86_64 x86_64
$ ros setup
Installing sbcl-bin...
No SBCL version specified. Downloading platform-table.html to see the available versions...
[##########################################################################]100%
Installing sbcl-bin/1.4.10...
Downloading https://github.com/roswell/sbcl_bin/releases/download/1.4.10/sbcl-1.4.10-x86-64-darwin-binary.tar.bz2
Download Failed with status 2. See download_simple in src/download.c
zsh: segmentation fault  ros
$ ros -v -v setup
opt:verbose:1
dispatch:-v,name=top
proc_options:-v:top
opt:verbose:3
s 140393118178576 util-list.c 147 "-v":done
dispatch:setup,name=top
proc_cmd:
s 140393118178528 util-dir.c 81 "ROSWELL_HOME":done
q 140393118178560 4441557735 util-dir.c 83 ".roswell/"
q 140393118178672 140393118171200 cmd-internal.c 157 "/usr/local/etc/roswell/"
s 140393118178576 proc-opt.c 101 "/Users/yuya/.roswell/":done
s 140393118178672 proc-opt.c 101 "/usr/local/etc/roswell/":done
s 140393118178672 proc-opt.c 109 "/Users/yuya/.roswell/setup.ros":done
dispatch:/usr/local/etc/roswell/setup.ros,name=top
proc_cmd:
cmd_script_frontend:0
frontend:script_*:argc=1 argv[0]=/usr/local/etc/roswell/setup.ros
ros_script_cmd=exec ros -Q -N roswell -- $0 "$@"
s 140393118179040 util-cmdline.c 39 "$@":done
dispatch:-Q,name=top
proc_options:-Q:top
opt:quicklisp:2
s 140393118179040 util-list.c 147 "-Q":done
dispatch:-N,name=top
proc_options:-N:top
get_opt(roswellenv,0)=(null)
take1:roswellenv:roswell,(null)
set_opt(roswellenv)='roswell'
s 140393118179184 util-list.c 147 "-N":done
s 140393118179232 util-list.c 147 "roswell":done
dispatch:--,name=top
proc_options:--:top
cmd_script_frontend:1
cmd_script
get_opt(program,0)=(null)
script_:argc=2 argv[0]=--
current=(null)
q 140393118179184 4441562424 cmd-script.c 18 ""
s 140393118179200 cmd-script.c 23 "/usr/local/etc/roswell/setup.ros":done
set_opt(script)='"/usr/local/etc/roswell/setup.ros"'
s 140393118179504 cmd-script.c 26 ""/usr/local/etc/roswell/setup.ros"":done
q 140393118179552 140393118179440 util-list.c 178 "script"
s 140393118179440 util-list.c 147 "script":done
cmd_run_star:1:argv[0],script
s 140393118179440 util-dir.c 81 "ROSWELL_HOME":done
q 140393118179472 4441557735 util-dir.c 83 ".roswell/"
get_opt(image,0)=(null)
get_opt(roswellenv,0)=roswell
s 140393118179472 util-dir.c 81 "ROSWELL_HOME":done
q 140393118179536 4441557735 util-dir.c 83 ".roswell/"
get_opt(roswellenv,1)q 140393118179536 4441556769 opt.c 114 "roswellenv"
s 140393118179536 opt.c 116 "roswellenv":done
=roswell
s 140393118179664 util-string.c 183 "/Users/yuya/.roswell/env/roswell/config":done
set_env_opt:/Users/yuya/.roswell/env/roswell/config
get_opt(lisp,1)q 140393118179536 4441556761 opt.c 114 "lisp"
s 140393118179536 opt.c 116 "lisp":done
=(null)
get_opt(*lisp,0)=(null)
get_opt(default.lisp,0)=(null)
determin_impl:(null)
get_opt(default.lisp,1)q 140393118179536 4441558080 opt.c 114 "default.lisp"
s 140393118179536 opt.c 116 "default_lisp":done
=(null)
q 140393118179536 4441562410 cmd-run.c 79 "sbcl-bin"
s 140393118179536 cmd-run.c 89 "sbcl-bin":done
q 140393117123616 4441562410 cmd-run.c 90 "sbcl-bin"
s 140393117123632 util-dir.c 81 "ROSWELL_HOME":done
q 140393117123664 4441557735 util-dir.c 83 ".roswell/"
q 140393117123664 4441557118 util.c 137 "tmp"
q 140393117123648 4441556373 util.c 137 "/"
ensure_directories_exist:/Users/yuya/.roswell/tmp/
s 140393117123680 util.c 139 "/Users/yuya/.roswell/tmp/":done
s 140393117123648 util-dir.c 81 "ROSWELL_HOME":done
q 140393117123680 4441557735 util-dir.c 83 ".roswell/"
q 140393117123776 4441557476 util.c 140 "tmp/lock.roswell."
q 140393117123680 4441558943 util.c 140 "setup"
lock setup exist status=0s 140393117123856 util.c 148 "/Users/yuya/.roswell/tmp/lock.roswell.setup":done
s 140393117123664 util-dir.c 81 "ROSWELL_HOME":done
q 140393117123696 4441557735 util-dir.c 83 ".roswell/"
q 140393117123696 4441557118 util.c 137 "tmp"
q 140393117123680 4441556373 util.c 137 "/"
ensure_directories_exist:/Users/yuya/.roswell/tmp/
s 140393117123744 util.c 139 "/Users/yuya/.roswell/tmp/":done
s 140393117123680 util-dir.c 81 "ROSWELL_HOME":done
q 140393117123744 4441557735 util-dir.c 83 ".roswell/"
q 140393117123840 4441557476 util.c 140 "tmp/lock.roswell."
q 140393117123744 4441558943 util.c 140 "setup"
lock!:setup
s 140393117123920 util.c 148 "/Users/yuya/.roswell/tmp/lock.roswell.setup":done
verbose-option:''
get_opt(sbcl-bin.version,0)=(null)
Installing sbcl-bin...
ros install sbcl-bin
System:ros install sbcl-bin
No SBCL version specified. Downloading platform-table.html to see the available versions...
[##########################################################################]100%
Installing sbcl-bin/1.4.10...
Downloading https://github.com/roswell/sbcl_bin/releases/download/1.4.10/sbcl-1.4.10-x86-64-darwin-binary.tar.bz2
Download Failed with status 2. See download_simple in src/download.c
s 140393116126032 cmd-run.c 51 "ros install sbcl-bin":done
s 140393116126320 util-dir.c 81 "ROSWELL_HOME":done
q 140393116126032 4441557735 util-dir.c 83 ".roswell/"
q 140393116126032 4441557118 util.c 137 "tmp"
q 140393116125024 4441556373 util.c 137 "/"
ensure_directories_exist:/Users/yuya/.roswell/tmp/
s 140393116126048 util.c 139 "/Users/yuya/.roswell/tmp/":done
s 140393116125024 util-dir.c 81 "ROSWELL_HOME":done
q 140393116126048 4441557735 util-dir.c 83 ".roswell/"
q 140393116124048 4441557476 util.c 140 "tmp/lock.roswell."
q 140393116126048 4441558943 util.c 140 "setup"
unlock!:setup
s 140393116124128 util.c 148 "/Users/yuya/.roswell/tmp/lock.roswell.setup":done
s 140393116126032 util-dir.c 81 "ROSWELL_HOME":done
q 140393116126064 4441557735 util-dir.c 83 ".roswell/"
q 140393116126064 4441556144 cmd-run.c 92 "config"
s 140393116124048 cmd-run.c 93 "/Users/yuya/.roswell/config":done
get_opt(sbcl-bin.version,0)=(null)
q 140393116126048 4441556373 cmd-run.c 96 "/"
set_opt(impl)='sbcl-bin/'
get_opt(quicklisp,0)=(null)
s 140393116124176 util-string.c 183 "/Users/yuya/.roswell/lisp/quicklisp/":done
set_opt(quicklisp)='/Users/yuya/.roswell/lisp/quicklisp/'
set_opt(argv0)='ros'
which cmd:command -v "ros"
q 140393116124368 4441562424 util-system.c 9 ""
q 140393116124448 140732774224992 util-system.c 15 "/usr/local/bin/ros
"
which result:/usr/local/bin/ros

s 140393116124480 util.c 57 "/usr/local/bin/ros":done
s 140393116124384 util.c 57 "command -v "ros"":done
set_opt(wargv0)='/usr/local/bin/ros'
q 140393117123840 140393118179504 cmd-run.c 149 "/Users/yuya/.roswell/"
set_opt(homedir)='/Users/yuya/.roswell/'
set_opt(verbose)='3'
q 140393117122592 140393118171200 cmd-internal.c 157 "/usr/local/etc/roswell/"
q 140393117122624 140393117122592 cmd-run.c 151 "/usr/local/etc/roswell/"
set_opt(lispdir)='/usr/local/etc/roswell/'
q 140393117122768 140393117122736 cmd-run.c 152 "/usr/local/etc/roswell/patch/"
q 140393117122800 140393117122768 util-string.c 155 "/usr/local/etc/roswell/patch/"
set_opt(patchdir)='/usr/local/etc/roswell/patch/'
get_opt(asdf.version,0)=(null)
q 140393115025888 4441562424 util-system.c 9 ""
q 140393116124352 140732774225024 util-system.c 15 "Darwin
"
s 140393116124368 util.c 9 "Darwin
":done
set_opt(uname)='darwin'
q 140393117122992 4441562424 util-system.c 9 ""
q 140393115025888 140732774225008 util-system.c 15 "x86_64
"
s 140393115027472 util.c 17 "x86_64
":done
set_opt(uname-m)='x86-64'
s 140393118179504 cmd-run.c 157 "/Users/yuya/.roswell/":done
get_opt(program,0)=(null)
s 140393117123072 util-dir.c 81 "ROSWELL_HOME":done
q 140393117123104 4441557735 util-dir.c 83 ".roswell/"
q 140393117123104 4441559401 cmd-run.c 162 "init.lisp"
get_opt(asdf.version,0)=(null)
q 140393117123104 4441562424 cmd-run.c 164 ""
q 140393117123120 4441559442 cmd-run.c 165 "(:eval"(ros:quicklisp)")"
q 140393117123088 4441562424 cmd-run.c 166 ""
q 140393117123184 4441562424 cmd-run.c 167 ""
q 140393117123200 4441562424 cmd-run.c 168 ""
s 140393117123152 cmd-run.c 169 "/Users/yuya/.roswell/init.lisp":done
set_opt(program)='(:eval"(ros:quicklisp)")'
get_opt(impl,0)=sbcl-bin/
s 140393117123216 util-dir.c 81 "ROSWELL_HOME":done
q 140393117123248 4441557735 util-dir.c 83 ".roswell/"
q 140393117123248 4441562424 util-system.c 9 ""
q 140393115027472 140732774224768 util-system.c 15 "x86_64
"
s 140393115025888 util.c 17 "x86_64
":done
q 140393117123232 4441562424 util-system.c 9 ""
q 140393116124368 140732774224784 util-system.c 15 "Darwin
"
s 140393116124352 util.c 9 "Darwin
":done
get_opt(help,0)=(null)
get_opt(script,0)="/usr/local/etc/roswell/setup.ros"
get_opt(image,0)=(null)
get_opt(program,0)=(:eval"(ros:quicklisp)")
get_opt(dynamic-space-size,0)=(null)
get_opt(control-stack-size,0)=(null)
get_opt(without-roswell,0)=(null)
get_opt(enable-debugger,0)=(null)
zsh: segmentation fault  ros -v -v setup
```

This patch changes sbcl_bin_download to one that supports two-digits case.