### PR TITLE
Fix lispdir on Windows

### DIFF
--- a/src/cmd-internal.c
+++ b/src/cmd-internal.c
@@ -157,7 +157,7 @@ char* lispdir(void) {
     return q(result);
 
   w=which(argv_orig[0]);
-  ros_bin=pathname_directory(truename(w));
+  ros_bin=append_trail_slash(pathname_directory(truename(w)));
   s(w);
 
   /* $(bindir)/lisp/ */


### PR DESCRIPTION
I got a following error and I changed lispdir function in src/cmd-internal.c .
I don't know this is windows specific problem.
If so, this change might cause problems on other platforms...

OS: Windows 8.1 (64bit)
DevTool: MSYS2/MinGW-w64 (64bit) (gcc version 7.3.0 (Rev2, Built by MSYS2 project))

```
> ros run

Unhandled SB-INT:SIMPLE-FILE-ERROR in thread #<SB-THREAD:THREAD "main thread" RUNNING
                                                {1002DBBA43}>:
  Couldn't load
  "C:/projects/roswell-en89n/msys64/mingw64/etc/roswell\\\\init.lisp": file
  does not exist.

Backtrace for: #<SB-THREAD:THREAD "main thread" RUNNING {1002DBBA43}>
0: (SB-DEBUG::DEBUGGER-DISABLED-HOOK #<SB-INT:SIMPLE-FILE-ERROR "~@<Couldn't load ~S: file does not exist.~@:>" {1002DDCB23}> #<unused argument>)
1: (SB-DEBUG::RUN-HOOK *INVOKE-DEBUGGER-HOOK* #<SB-INT:SIMPLE-FILE-ERROR "~@<Couldn't load ~S: file does not exist.~@:>" {1002DDCB23}>)
2: (INVOKE-DEBUGGER #<SB-INT:SIMPLE-FILE-ERROR "~@<Couldn't load ~S: file does not exist.~@:>" {1002DDCB23}>)
3: (ERROR SB-INT:SIMPLE-FILE-ERROR :PATHNAME "C:/projects/roswell-en89n/msys64/mingw64/etc/roswell\\\\init.lisp" :FORMAT-CONTROL "~@<Couldn't load ~S: file does not exist.~@:>" :FORMAT-ARGUMENTS ("C:/projects/roswell-en89n/msys64/mingw64/etc/roswell\\\\init.lisp"))
4: (LOAD "C:/projects/roswell-en89n/msys64/mingw64/etc/roswell\\\\init.lisp" :VERBOSE NIL :PRINT NIL :IF-DOES-NOT-EXIST T :EXTERNAL-FORMAT :DEFAULT)
5: (SB-INT:SIMPLE-EVAL-IN-LEXENV (LOAD "C:/projects/roswell-en89n/msys64/mingw64/etc/roswell\\\\init.lisp") #<NULL-LEXENV>)
6: (SB-INT:SIMPLE-EVAL-IN-LEXENV (PROGN (LOAD "C:/projects/roswell-en89n/msys64/mingw64/etc/roswell\\\\init.lisp")) #<NULL-LEXENV>)
7: (EVAL (PROGN (LOAD "C:/projects/roswell-en89n/msys64/mingw64/etc/roswell\\\\init.lisp")))
8: (SB-IMPL::PROCESS-EVAL/LOAD-OPTIONS ((:EVAL . "(progn #-ros.init(cl:load \"C:/projects/roswell-en89n/msys64/mingw64/etc/roswell\\\\\\\\init.lisp\"))") (:EVAL . "(ros:run '((:eval\"(ros:quicklisp)\")(:script \"help\")(:quit ())))")))
9: (SB-IMPL::TOPLEVEL-INIT)
10: ((FLET #:WITHOUT-INTERRUPTS-BODY-74 :IN SAVE-LISP-AND-DIE))
11: ((LABELS SB-IMPL::RESTART-LISP :IN SAVE-LISP-AND-DIE))
12: ("foreign function: #x4338BC")
13: ("foreign function: #x403751")

unhandled condition in --disable-debugger mode, quitting
```
