### PR TITLE
Fix lispdir on Windows v2

### DIFF
--- a/src/cmd-internal.c
+++ b/src/cmd-internal.c
@@ -157,7 +157,7 @@ char* lispdir(void) {
     return q(result);
 
   w=which(argv_orig[0]);
-  ros_bin=append_trail_slash(pathname_directory(truename(w)));
+  ros_bin=pathname_directory(truename(w));
   s(w);
 
   /* $(bindir)/lisp/ */

--- a/src/util-dir.c
+++ b/src/util-dir.c
@@ -91,7 +91,7 @@ char* pathname_directory(char* path) {
   int i;
   char* ret;
   for(i=strlen(path)-1;i>=0&&path[i]!=SLASH[0];--i);
-  ret=(i>=0)?subseq(path,0,i):append_trail_slash(".");
+  ret=(i>=0)?subseq(path,0,i+1):append_trail_slash(".");
   s(path);
   return ret;
 }


### PR DESCRIPTION
Sorry, I reverted #334 and changed pathname_directory function in src/util-dir.c .

The problem seems to be introduced by #326 (2018-5-21).

I also found similar issue #327 (2018-6-10).
