### PR TITLE
Change .appveyor.yml for MSYS2 x86_64

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -27,7 +27,7 @@ install:
            do pacman --noconfirm -Suy autoconf automake mingw-w64-"+ $env:MSYS2_ARCH + "-gcc make zlib-devel python3 && break || sleep 15; done");
          &("msys" + $env:MSYS2_BITS + "\usr\bin\bash") -lc "pacman --noconfirm -R -s bash-completion tftp-hpa inetutils util-linux tzcode time dash flex pax-git file bsdcpio bsdtar lndir";
          &("msys" + $env:MSYS2_BITS + "\usr\bin\bash") -lc "yes|pacman --noconfirm -Sc";
-         &("msys" + $env:MSYS2_BITS + "\autorebase.bat");
+         #&("msys" + $env:MSYS2_BITS + "\autorebase.bat");
         }
 
 build_script:


### PR DESCRIPTION
It seems that AppVeyor MSYS2 x86_64 job has failed many times
and Roswell-x86_64.zip has not created since 2018-6-20.

AppVeyor log is as follows:
```
autorebase.bat : rebase: Invalid Baseaddress 0x70000000, must be > 0x200000000
At line:12 char:5
+     &("msys" + $env:MSYS2_BITS + "\autorebase.bat");
+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (rebase: Invalid...e > 0x200000000:String) [], RemoteException
    + FullyQualifiedErrorId : NativeCommandError
 
Command executed with exception: rebase: Invalid Baseaddress 0x70000000, must be > 0x200000000
```

I commented out the line calling autorebase.bat
and confirmed the job succeeded.

(Though, I don't understand the roll of autorebase.bat well ...)
