### PR TITLE
Fix ros emacs for windows

### DIFF
--- a/lisp/emacs.ros
+++ b/lisp/emacs.ros
@@ -31,6 +31,11 @@ exec ros -m roswell -N roswell -- $0 "$@"
     (mute-error-if-not-verbose
      (roswell:exec
       `("emacs" "-l" ,(namestring path) "--eval"
-                ,(format nil "(setq inferior-lisp-program \"ros -Q ~:[~;~:*-L ~A ~]run\")" (roswell:opt "*lisp"))
+                ,(format nil
+                         #-win32
+                         "(setq inferior-lisp-program \"ros -Q ~:[~;~:*-L ~A ~]run\")"
+                         #+win32
+                         "\"(setq inferior-lisp-program \\\"ros -Q ~:[~;~:*-L ~A ~]run\\\")\""
+                         (roswell:opt "*lisp"))
                 ,@argv)))))
 ;;; vim: set ft=lisp lisp:

--- a/lisp/install-slime.lisp
+++ b/lisp/install-slime.lisp
@@ -82,7 +82,10 @@
     (format *error-output* "~{~A~%~}"
             `(,(format nil "helper.el installed in ~S" (namestring target)) ""
               "To use, add this to your ~/.emacs:" ""
-              ,(format nil "  (load (expand-file-name ~S))" enough)))))
+              ,(format nil
+                       "  (load (expand-file-name ~S))"
+                       #-win32 enough
+                       #+win32 (namestring target))))))
 
 (defun slime-install (argv)
   (let ((name (or (getf argv :version) (substitute #\. #\- (ql:dist-version "quicklisp")))))


### PR DESCRIPTION
1. emacs displayed a following message when invoked by 'ros emacs' on windows.
   ```
   End of file during parsing
   ```
   I changed lisp/emacs.ros .
   (I added and escaped double quotes)


2. 'ros emacs' displayed a following message.
   ```
   helper.el installed in "C:/Users/user/.roswell/helper.el"
   
   To use, add this to your ~/.emacs:
   
     (load (expand-file-name "~//Users/user/.roswell/helper.el"))
   ```
   But `"~//Users/user/.roswell/helper.el"` is a wrong path.
   I changed lisp/install-slime.lisp .
   (There seems to be two problems.
   One is windows drive letter problem.
   Another is environment variable HOME (<- MSYS2) and USERPROFILE (<- windows) mismatch.
   I gave up using 'enough path' and used 'target path' .)


OS: Windows 8.1 (64bit)
Roswell version 18.8.10.93
