### PR TITLE
Allow cloned repos to work correctly with travis-cl.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ env:
     - ROSWELL_BRANCH=$TRAVIS_BRANCH
     - ROSWELL_INSTALL_DIR=$HOME/.roswell
     - ROSWELL_QUICKLISP_DIST_URI=https://github.com/roswell/quicklisp/releases/download/dist/quicklisp.txt
+    - ROSWELL_REPO=https://github.com/${TRAVIS_REPO_SLUG}
   matrix:
     - METHOD=ci LISP=alisp
     - METHOD=ci LISP=cmu-bin/2017-10

--- a/scripts/install-for-ci.sh
+++ b/scripts/install-for-ci.sh
@@ -3,7 +3,7 @@ set -e
 
 ROSWELL_TARBALL_PATH=$HOME/roswell.tar.gz
 ROSWELL_DIR=$HOME/.roswell
-ROSWELL_REPO=${ROSWELL_REPO:-https://github.com/${TRAVIS_REPO_SLUG}}
+ROSWELL_REPO=${ROSWELL_REPO:-https://github.com/roswell/roswell}
 ROSWELL_BRANCH=${ROSWELL_BRANCH:-release}
 ROSWELL_INSTALL_DIR=${ROSWELL_INSTALL_DIR:-/usr/local}
 ROSWELL_PLATFORMHTML_BASE=${ROSWELL_PLATFORMHTML_BASE:-https://github.com/roswell/sbcl_bin/releases/download/files/build.html}

--- a/scripts/install-for-ci.sh
+++ b/scripts/install-for-ci.sh
@@ -3,7 +3,7 @@ set -e
 
 ROSWELL_TARBALL_PATH=$HOME/roswell.tar.gz
 ROSWELL_DIR=$HOME/.roswell
-ROSWELL_REPO=${ROSWELL_REPO:-https://github.com/roswell/roswell}
+ROSWELL_REPO=${ROSWELL_REPO:-https://github.com/${TRAVIS_REPO_SLUG}}
 ROSWELL_BRANCH=${ROSWELL_BRANCH:-release}
 ROSWELL_INSTALL_DIR=${ROSWELL_INSTALL_DIR:-/usr/local}
 ROSWELL_PLATFORMHTML_BASE=${ROSWELL_PLATFORMHTML_BASE:-https://github.com/roswell/sbcl_bin/releases/download/files/build.html}


### PR DESCRIPTION
Fix for #356 use the ${TRAVIS_REP_SLUG} to refer to your own repo from travis. This is **the right thing** in a repo that could be cloned.