### PR TITLE
Fix #359

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,5 +1,5 @@
-roslispdir = $(sysconfdir)/$(PACKAGE)
-roslisppatchdir = $(sysconfdir)/$(PACKAGE)/patch
+roslispdir = @roslispdir@
+roslisppatchdir = @roslisppatchdir@
 SUBDIRS = src
 
 if MANUAL_INSTALL
@@ -92,19 +92,6 @@ roslisp_DATA = $(LISPS:%=lisp/%)
 
 roslisppatch_DATA = patch/sbcl-1.3.11.patch patch/sbcl-posix-tests.patch
 
-src/gend.h: FORCE
-	printf '#define ROS_COMPILE_ENVIRONMENT "%s"\n' "`$(CC) --version|head -n 1`" > $@.tmp
-	(printf "#define ROS_REVISION \"" && ((which git>/dev/null&&[ -e .git ]&& \
-	(git log -n 1 --oneline|cut -d' ' -f1| tr -d '\n'| tr -d '\r'))||printf "") && printf "\"\n") >> $@.tmp
-	printf '#define PATCH_PATH "%s"\n' "$(roslisppatchdir)" >> $@.tmp
-if WITH_WINDOWS
-	printf '#define LISP_PATH "%s"\n' "`mkdir -p $(roslispdir);cd $(roslispdir); pwd -W 2>/dev/null`" >> $@.tmp
-else
-	printf '#define LISP_PATH "%s"\n' "$(roslispdir)" >> $@.tmp
-endif
-	cmp -s $@.tmp $@||cp $@.tmp $@
-	cat $@
-	rm -f $@.tmp
 
 release-prepare:
 	ros scripts/release.ros prepare

--- a/configure.ac
+++ b/configure.ac
@@ -35,10 +35,17 @@ AM_CONDITIONAL([WITH_WINDOWS], [test "$with_windows" != ""])
 AC_CHECK_TOOL([WINDRES], [windres], [])
 AM_CONDITIONAL([WITH_WIN_ICON], [test "$WINDRES" != ""])
 
-# This code needs git
-# Check for git source version at config time
-AC_SUBST([git_version], m4_esyscmd_s([git describe |  sed -n -e 's/^.*-g//p'],[git SHA1 for HEAD.])) 
-AC_SUBST([git_version_long], m4_esyscmd_s([git describe --abbrev=7 --dirty]), [long version for git source])
+# Git is optional, so fail gracefully, build from tar may not have .git/
+AC_CHECK_PROG(GIT_CHECK,git,yes)
+AS_IF([test "x$GIT_CHECK" = xyes],
+      [AC_SUBST([git_version], `set -o pipefail ; { git describe  | sed -n -e 's/^.*-g//p' ; } 2>/dev/null || echo 'NO-GIT-REVISION'
+`,[git SHA1 for HEAD.])],
+      [AC_SUBST([git_version],[NO-GIT-REVISION])])
+      
+AS_IF([test "x$GIT_CHECK" = xyes],      
+      [AC_SUBST([git_version_long], `set -e | git describe --abbrev=7 --dirty 2>/dev/null || echo 'NO-GIT-REVISION'`, [long version for git source])],
+      [AC_SUBST([git_version_long], [NO-GIT-REVISION])])
+
 
 # Define rosdir and rospatchdir
 # TODO: Make these ./configure line options.

--- a/configure.ac
+++ b/configure.ac
@@ -4,6 +4,8 @@
 AC_PREREQ([2.59])
 AC_INIT([roswell],[19.3.10.97],snmsts@gmail.com)
 
+
+
 AM_CONFIG_HEADER(config.h)
 AC_CONFIG_FILES([Makefile src/Makefile])
 AC_CONFIG_SRCDIR([Makefile.am])
@@ -32,6 +34,20 @@ AC_CHECK_HEADERS(windows.h,[with_windows=true])
 AM_CONDITIONAL([WITH_WINDOWS], [test "$with_windows" != ""])
 AC_CHECK_TOOL([WINDRES], [windres], [])
 AM_CONDITIONAL([WITH_WIN_ICON], [test "$WINDRES" != ""])
+
+# This code needs git
+# Check for git source version at config time
+AC_SUBST([git_version], m4_esyscmd_s([git describe |  sed -n -e 's/^.*-g//p'],[git SHA1 for HEAD.])) 
+AC_SUBST([git_version_long], m4_esyscmd_s([git describe --abbrev=7 --dirty]), [long version for git source])
+
+# Define rosdir and rospatchdir
+# TODO: Make these ./configure line options.
+# See https://www.gnu.org/prep/standards/html_node/Directory-Variables.html#Directory-Variables
+# Especially 'lispdir' example for emacs.
+roslispdir='${sysconfdir}/roswell'
+AC_SUBST(roslispdir)
+roslisppatchdir='${roslispdir}/patch'
+AC_SUBST(roslisppatchdir)
 
 # Change master uri for sbcl-bin
 AC_ARG_WITH([sbcl_bin_base],

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -7,8 +7,20 @@ html_sbcl_SOURCES =  html.c html-sbcl-bin.c main.c opt.c $(ros_utils)
 html_sbcl_CFLAGS = "-D ROSWELL_HTML_TEST"
 
 gend.h: FORCE
-	make -C .. src/gend.h
-cmd-internal.c: gend.h
+	printf '#define ROS_COMPILE_ENVIRONMENT "%s"\n' "`$(CC) --version|head -n 1`" > $@.tmp
+	printf '#define ROS_REVISION "@git_version@"\n' >> $@.tmp
+	printf '#define PATCH_PATH "@roslisppatchdir@"\n' >> $@.tmp
+if WITH_WINDOWS
+	printf '#define LISP_PATH "%s"\n' "`mkdir -p @roslispdir@;cd @roslispdir@; pwd -W 2>/dev/null`" >> $@.tmp
+else
+	printf '#define LISP_PATH "@roslispdir@"\n' >> $@.tmp
+endif
+	cmp -s $@.tmp $@||cp $@.tmp $@
+	cat $@
+	rm -f $@.tmp
+
+cmd-internal.o: gend.h
+
 bin_PROGRAMS = ros
 ros_SOURCES = main.c opt.c download.c download_windows.c archive.c archive_windows.c \
 	register-commands.c html.c html-sbcl-bin.c \


### PR DESCRIPTION
**PLEASE REVIEW THIS CAREFULLY BECAUSE AUTOCONFIG AND AUTOMAKE MISTAKES BREAK THE BUILD.**

**The terse commit-like description of changes**

Makefile.am Remove: gend.h generation
src/Makefile.am Added gend.h generation
   cmd-external.o is dependent on gend.h
   gend.h is build from autoconf vars

**The very long description of how and why**

Most of my thinking in #359 was largely valid. To make `gend.h` as a dependency of `cmd-internal.o`  the recipe is a file containing these defines:
1) `#define ROS_VERSION` is directly substituted from `git_version` which is computed in configure.ac by a call to `git describe` and filter through sed. 
2) `#define **ROSLISPDIR` and `#define ROSLISPPATHDIR` are respectfully substituted from  `roslispdir` and `roslisppatchdir` which are defined in configure.ac.
3) `#define ROS_COMPILE_ENVIRONMENT` is computed much as before, that is from version string from the compiler command line at make time. 

The only extra feature I added beyond was necessary to fix #359 was the addition of the `git_version_long` definition next to `git_version.` 

**My testing for these changes**

My out-of-source build script on msys2/mingw64 build shell.

```sh
#! /bin/sh
git log -n 1
uname -a
sh bootstrap
mkdir build
cd build
../configure
make
make install
ros --version
ros config
```
Correct build with this fix should meet all these conditions:
1) Expected Behaviour as defined in #359 is output from above script.
2) Travis passes expected tests
3) Appveyor produces artifacts

On my system all these conditions seem to pass.

**Need more detail on these changes?**

Read the changes and please comment or email.

Thank you for considering these changes