### PR TITLE
Add script for appimage

### DIFF
--- a/scripts/build-appimage.sh
+++ b/scripts/build-appimage.sh
@@ -1,0 +1,33 @@
+#!/bin/sh -ex
+deploy=linuxdeploy-x86_64.AppImage
+desktop=roswell.desktop
+icon=roswell.png
+# Download the toolchain
+curl -fsSLO "https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/$deploy"
+# Make it executable
+chmod +x "./$deploy"
+# Download the icon
+curl -fsSL "https://avatars0.githubusercontent.com/u/16501222?s=256&v=4" -o "$icon"
+# Build appimage
+cat <<EOF > "$desktop"
+[Desktop Entry]
+Version=1.0
+Type=Application
+Name=Roswell
+Comment=intend to be a lisp installer and launcher for major environment that just work.
+Categories=ConsoleOnly;Development;
+TryExec=ros
+Exec=ros -- %F
+Icon=roswell
+Terminal=true
+MimeType=image/png;
+EOF
+appdir=`mktemp -d`
+./$deploy \
+    --icon-file="$icon" \
+    --desktop-file="roswell.desktop" \
+    --appdir="$appdir" \
+    --executable="$1" \
+    --output=appimage
+rm -rf $appdir $deploy $desktop
+


### PR DESCRIPTION
This pull request relates to #365. I made a script for appimage. 
The attached file is made with this script. This runs on **every** linux x86_64 platforms. Please try It.
```
$ gunzip Roswell-x86_64.AppImage.gz
$ ./Roswell-x86_64.AppImage run
```

[Roswell-x86_64.AppImage.gz](https://github.com/roswell/roswell/files/3007946/Roswell-x86_64.AppImage.gz)