### PR TITLE
use correct lispworks command line argument -eval

### DIFF
--- a/src/cmd-run-lispworks.c
+++ b/src/cmd-run-lispworks.c
@@ -15,14 +15,14 @@ char** cmd_run_lispworks(int argc,char** argv,struct sub_command* cmd) {
   ret=conss(cat(home,"impls",SLASH,arch,SLASH,os,SLASH,"LispWorks",SLASH,"lw-console",NULL), ret);
 
   if(lw_version) {
-    ret=conss(q("--eval"),ret);
+    ret=conss(q("-eval"),ret);
     ret=conss(q("(progn (format t \"~A ~A~%\" (lisp-implementation-type) (lisp-implementation-version))(lw:quit))"),ret);
   }
 
-  ret=conss(q("--eval"),ret);
+  ret=conss(q("-eval"),ret);
   ret=conss(s_cat(q("(progn #-ros.init(cl:load \""),s_escape_string(lispdir()),q("init.lisp"),q("\"))"),NULL),ret);
   if(program || script) {
-    ret=conss(q("--eval"),ret);
+    ret=conss(q("-eval"),ret);
     ret=conss(s_cat(q("(ros:run '("),q(program?program:""),
                     script?cat("(:script ",script,")","(:quit ())",NULL):q(""),
                     q("))"),NULL),ret);


### PR DESCRIPTION
According to LispWorks manual: 
http://www.lispworks.com/documentation/lw60/LW/html/lw-484.htm
http://www.lispworks.com/documentation/lw71/LW/html/lw-210.htm

The command line argument should be "-eval" instead of "--eval" in LispWorks.