### PR TITLE
Fix CircleCI's working directory in install-for-ci

### DIFF
--- a/scripts/install-for-ci.sh
+++ b/scripts/install-for-ci.sh
@@ -236,6 +236,6 @@ mkdir -p "$LOCAL_LISP_TREE"
 if [ "$TRAVIS" ]; then
     echo "(:tree \"$TRAVIS_BUILD_DIR/\")" > "$ASDF_SR_CONF_FILE"
 elif [ "$CIRCLECI" ]; then
-    echo "(:tree \"$HOME/$CIRCLE_PROJECT_REPONAME/\")" > "$ASDF_SR_CONF_FILE"
+    echo "(:tree \"$CIRCLE_WORKING_DIRECTORY/\")" > "$ASDF_SR_CONF_FILE"
 fi
 echo "(:tree \"$LOCAL_LISP_TREE/\")" >> "$ASDF_SR_CONF_FILE"


### PR DESCRIPTION
Currently on CircleCI, `$CIRCLE_WORKING_DIRECTORY` (defaulting to `~/project`) is where the repository is cloned instead of `$HOME/$CIRCLE_PROJECT_REPONAME/`.

For demonstration, [current implementation](https://circleci.com/gh/neil-lindquist/CI-Utils/16), and [with the new directory added](https://circleci.com/gh/neil-lindquist/CI-Utils/17)