### PR TITLE
Fix the CI failure since sbcl-bin/1.5.6 had released

### DIFF
--- a/scripts/install-for-ci.sh
+++ b/scripts/install-for-ci.sh
@@ -187,6 +187,13 @@ case "$LISP" in
         ;;
 esac
 
+# sbcl-bin/1.5.6 requires libc6-2.28 but its Ubuntu package is too old.
+# https://packages.ubuntu.com/ja/bionic/libc6
+if [ `uname` = "Linux" ]; then
+    # Install sbcl-bin/1.5.5 explicitly before the latest sbcl-bin will be installed.
+    ros install sbcl-bin/1.5.5
+fi
+
 echo "Installing $LISP..."
 case "$LISP" in
     clisp)


### PR DESCRIPTION
The latest sbcl-bin, 1.5.6, requires libc6-2.28 or above, but [Ubuntu 18.04 (bionic) provides only libc6-2.27](https://packages.ubuntu.com/ja/bionic/libc6).
It causes `ros install sbcl-bin` -- or other sbcl-bin required operation -- will be failed with this error.

```
/home/travis/.roswell/impls/x86-64/linux/sbcl-bin/1.5.6/bin/sbcl: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.28' not found (required by /home/travis/.roswell/impls/x86-64/linux/sbcl-bin/1.5.6/bin/sbcl)
```

Since Roswell highly depends on sbcl-bin, many other `ros` command operations like `ros install ccl-bin` are also failed.

This patch changes script/install-for-ci.sh to install sbcl-bin/1.5.5 beforehand for preventing Roswell from installing the latest sbcl-bin.