### PR TITLE
Fix run-program not to concatenate its arguments.

### DIFF
--- a/lisp/init.lisp
+++ b/lisp/init.lisp
@@ -143,7 +143,7 @@ have the latest asdf, and this file has a workaround for this.
 
 (defun run-program (args &key output)
   (if (ignore-errors #1=(read-from-string "uiop/run-program:run-program"))
-      (funcall #1# (format nil "~{~A~^ ~}" args)
+      (funcall #1# (mapcar #'princ-to-string args)
                :output output
                #+(and sbcl win32) :force-shell #+(and sbcl win32) nil
                :error-output :interactive)


### PR DESCRIPTION
No need to concatenate its arguments since `uiop:run-program` can take a list of strings as its arguments.

> "Run program specified by COMMAND,
> either a list of strings specifying a program and list of arguments,
> or a string specifying a shell command (/bin/sh on Unix, CMD.EXE on Windows);

https://github.com/roswell/asdf/blob/master/uiop/run-program.lisp#L494-L496

This is for preventing from errors when the command contains some spaces in its path.