### PR TITLE
Use Roswell binary also for MinGW64.

### DIFF
--- a/scripts/install-for-ci.sh
+++ b/scripts/install-for-ci.sh
@@ -111,7 +111,7 @@ if which sudo >/dev/null; then
 fi
 
 install_roswell_bin () {
-    if uname -s | grep -e MSYS_NT >/dev/null; then
+    if uname -s | grep -E "MSYS_NT|MINGW" >/dev/null; then
         if [ $ROSWELL_BRANCH = release ]; then
             fetch "https://github.com/roswell/roswell/releases/download/v$ROSWELL_RELEASE_VERSION/roswell_${ROSWELL_RELEASE_VERSION}_amd64.zip" /tmp/roswell.zip
         else


### PR DESCRIPTION
This is required to run on Windows env of GitHub Actions.