### PR TITLE
Install SBCL under windows: automatically look for msiexec under windows system path

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3,14 +3,15 @@
 
 AC_PREREQ([2.59])
 AC_INIT([roswell],[19.09.12.102],snmsts@gmail.com)
-
-
+${CFLAGS=""}
+${CXXFLAGS=""}
 
 AM_CONFIG_HEADER(config.h)
 AC_CONFIG_FILES([Makefile src/Makefile])
 AC_CONFIG_SRCDIR([Makefile.am])
 AM_INIT_AUTOMAKE([foreign])
 AM_MAINTAINER_MODE([enable])
+
 
 # Checks for programs.
 AC_PROG_CC
@@ -19,6 +20,32 @@ AM_PROG_CC_C_O
 
 # Checks for libraries.
 wwwlib=no
+
+test -z "$SED" && SED=sed
+
+AC_ARG_ENABLE([debug],
+  [AS_HELP_STRING([--enable-debug],
+                  [whether to include debug symbols (default is no)])],
+  [enable_debug=$enableval],
+  [enable_debug=no]
+)
+
+if test "x$enable_debug" = xyes; then
+  dnl Remove all optimization flags from CFLAGS
+  changequote({,})
+  CFLAGS=`echo "$CFLAGS" | $SED -e 's/-O[0-9s]*//g'`
+  CXXFLAGS=`echo "$CXXFLAGS" | $SED -e 's/-O[0-9s]*//g'`
+
+  CFLAGS=`echo "$CFLAGS" | $SED -e 's/-g[0-9]*//g'`
+  CXXFLAGS=`echo "$CXXFLAGS" | $SED -e 's/-g[0-9]*//g'`
+  changequote([,])
+
+  CFLAGS="$CFLAGS -g -O0"
+  CXXFLAGS="$CXXFLAGS -g -O0"
+fi
+
+
+
 
 AC_CHECK_LIB([wininet], [main],[LIBS="-lwininet $LIBS";wwwlib=yes],[])
 if test "x$wwwlib" = xno; then
@@ -106,5 +133,7 @@ AM_CONDITIONAL(HTML_GENERATE,[test x$html_generate = x"true"])
 
 AM_COND_IF([MANUAL_INSTALL],
            [AC_CONFIG_FILES([documents/Makefile])])
+
+
 
 AC_OUTPUT

--- a/src/install-sbcl-bin_windows.c
+++ b/src/install-sbcl-bin_windows.c
@@ -1,7 +1,7 @@
 #include "opt.h"
 #ifdef HAVE_WINDOWS_H
 #include "cmd-install.h"
-
+#include "util.h"
 
 char* sbcl_bin_extention(struct install_options* param) {
   return ".msi";
@@ -19,6 +19,18 @@ int sbcl_bin_expand(struct install_options* param) {
   int pos=position_char("-",impl);
   impl=(pos!=-1)?subseq(impl,0,pos):q(impl);
   dist_path=cat(home,"src",SLASH,impl,"-",version,"-",arch,SLASH,NULL);
+  
+  char* msiexec_path="msiexec.exe";
+  if(!file_exist_p(msiexec_path))
+  {
+	  msiexec_path="C:\\Windows\\System32\\msiexec.exe";
+	  if(!file_exist_p(msiexec_path))
+	  {
+		  printf("Msiexec.exe not found in the system path\n");
+		  return 0;
+	  }
+  }
+  
   printf("Extracting the msi archive. %s to %s\n",archive,dist_path);
   archive=s_cat(q(home),q("archives"),q(SLASH),archive,NULL);
   delete_directory(dist_path,1);
@@ -27,7 +39,8 @@ int sbcl_bin_expand(struct install_options* param) {
   if(dist_path[strlen(dist_path)-1]=='\\')
     dist_path[strlen(dist_path)-1]='\0';
 
-  char* cmd=cat("msiexec.exe /a \"",
+  char* cmd=cat(msiexec_path,
+				" /a \"",
                 archive,
                 "\" targetdir=\"",
                 dist_path,


### PR DESCRIPTION
On Windows 10 the current version of roswell fails when C:\Windows\System32 is not added manually to the user Path system variable because msiexec is not found. This small patch automatically looks for msiexec also in C:\Windows\System32 when it is not found int the currentrly configured system path.