### PR TITLE
Added NULL check

### DIFF
--- a/src/install-sbcl-bin_windows.c
+++ b/src/install-sbcl-bin_windows.c
@@ -83,7 +83,7 @@ int sbcl_bin_expand(struct install_options* param) {
   dist_path=cat(home,"src",SLASH,impl,"-",version,"-",arch,SLASH,NULL);
  
   char* msiexec_path=msi_exec_path_from_register(); 
-  if(!file_exist_p(msiexec_path))
+  if(msiexec_path==NULL  || !file_exist_p(msiexec_path))
   {
 	  msiexec_path="msiexec.exe";
 	  if(!file_exist_p(msiexec_path))


### PR DESCRIPTION
Added a small NULL check to deal with the cases in which there is no registry key. The code still leaks the string returned from the msi_exec_path_from_register method but I guess it doesn't make sense to remove the leak as this would require basically copying the string into another and deallocating it at a later point. In fact the registry key might have trailing spaces and comes also with parameters afterwards that must be removed. For example a typical value is:

  %systemroot%\system32\msiexec.exe /V

Since Roswell is a command line tool that that ends after each invocation I believe we can live with this small leak with the benefit of having simpler code.