### PR TITLE
First partial fix to issue "`ros install sbcl` fails on Windows #395"

### DIFF
--- a/lisp/install+msys2.lisp
+++ b/lisp/install+msys2.lisp
@@ -53,17 +53,25 @@
           (uiop/run-program:run-program
            `(,(uiop:native-namestring (merge-pathnames "usr/bin/bash" msys))
              "-lc" " ")
-           :output t)
+           :output t
+           :error-output t)
+
+          (dotimes (i 3)
+            (uiop/run-program:run-program
+             `(,(uiop:native-namestring (merge-pathnames "usr/bin/bash" msys))
+               "-lc"
+               ,(format nil "~@{~A~}"
+                        "pacman --noconfirm "
+                        "-Suy autoconf automake pkg-config "
+                        "mingw-w64-" *msys2-arch* "-gcc "
+                        "make zlib-devel"))
+             :output t
+             :error-output t))
+          
           (uiop/run-program:run-program
-           `(,(uiop:native-namestring (merge-pathnames "usr/bin/bash" msys))
-             "-lc"
-             ,(format nil "~@{~A~}"
-                      "for i in {1..3}; do pacman --noconfirm "
-                      "-Suy autoconf automake pkg-config "
-                      "mingw-w64-" *msys2-arch* "-gcc "
-                      "make zlib-devel && break || sleep 15; done")))
-          (uiop/run-program:run-program
-           `(,(uiop:native-namestring (merge-pathnames "autorebase.bat" msys))))
+           `(,(uiop:native-namestring (merge-pathnames "autorebase.bat" msys)))
+           :output t
+           :error-output t)
           (setf (config "msys2.version") (getf argv :version)))))
   (cons t argv))
 

--- a/lisp/util-install-quicklisp.lisp
+++ b/lisp/util-install-quicklisp.lisp
@@ -1,6 +1,6 @@
 (roswell:include '("util-install" "system") "util-install-quicklisp")
 (roswell:quicklisp :environment nil)
-(ql:quickload '("uiop" "simple-date-time" "split-sequence" "plump" "cl-ppcre" #+win32 :zip) :silent t)
+(ql:quickload '("uiop" "simple-date-time" "split-sequence" "plump" "cl-ppcre" :cl-fad #+win32 :zip) :silent t)
 (in-package :roswell.install)
 
 (defvar *build-hook* nil)
@@ -47,8 +47,13 @@
 ;;end here from util/opts.c
 
 (defun installedp (argv)
-  ;; TBD support library like msys2,externals-clasp
-  (and (probe-file (merge-pathnames (format nil "impls/~A/~A/~A/~A/" (uname-m) (uname) (getf argv :target) (opt "as")) (homedir))) t))
+  (let ((implpath  (merge-pathnames (format nil "impls/~A/~A/~A/~A/" (uname-m) (uname) (getf argv :target) (opt "as")) (homedir))))
+    (format t "Checking for installed implementation in ~A " implpath)
+    (if (cl-fad:directory-exists-p implpath)
+        (directory (merge-pathnames implpath "*")) ;if the provided path is a directory then check that it's not empty
+        (probe-file implpath)))) ;else check if the file exists
+;; TBD support library like msys2,externals-clasp
+;(let implefiledir )(merge-pathnames (format nil "impls/~A/~A/~A/~A/" (uname-m) (uname) (getf argv :target) (opt "as")) (homedir)))
 
 (defvar *version-func* nil)
 


### PR DESCRIPTION
This allows to attempt to install SBCL a second time after compilation failure without getting the erroneous message that SBCL is already installed.
It's the first commit in a series that will address bug 395.
To succesfully install SBCL on Windos:
1- Apply this patch.
2- Run 'ros install sbcl' a first time. This first time installation will fail.
3- Open the Mingw64 command prompt that has been downloaded by Roswell (found under C:\Users\<Username>\.roswell\impls\x86-64\windows\msys2\<msys-version>\mingw64. Install the missing components of the build toolchain by running 'pacman --noconfirm -Suy autoconf automake pkg-config mingw-w64-x86_64-gcc make zlib-devel'
4- Run 'ros install sbcl' a second time. This time installation will succeed.

Changed the definition of 'installedp' to check also if the directory is empty and not only if it exists.
In fact on Windows an error during SBCL compilation might produce an empty
SBCL directory. In such cases checking only if the directory exists will
lead to erroneously detect an already installed SBCL version.