### PR TITLE
Fix "ros config" manual description

### DIFF
--- a/documents/man/ros-config.1
+++ b/documents/man/ros-config.1
@@ -10,12 +10,12 @@ ros\-config \- get and set options # Synopsis
 .PP
 Without any arguments, it shows all variables and it\[aq]s value.
 .TP
-.B show VAR
-set the VALUE to the TARGET.
+.B show TARGET
+show TARGET.
 .RS
 .RE
 .TP
-.B set VAR VALUE
+.B set TARGET VALUE
 set the VALUE to the TARGET.
 .RS
 .RE


### PR DESCRIPTION
The manual description was wrong, so I fixed it.

Thanks!