### PR TITLE
Update directory name for macOS

### DIFF
--- a/lisp/install-allegro.lisp
+++ b/lisp/install-allegro.lisp
@@ -55,7 +55,7 @@
                          (uiop:run-program
                           (format nil "hdiutil attach ~A | awk -F '\t' 'END{print $NF}'" (opt "download.archive"))
                           :output :string))))
-         (uiop:run-program (format nil "cp -r \"~A/AllegroCLexpress64.app/Contents/Resources/\" \"~A\""
+         (uiop:run-program (format nil "cp -r \"~A/AllegroCL64express.app/Contents/Resources/\" \"~A\""
                                    mount-dir
                                    (ensure-directories-exist (merge-pathnames (format nil "~A/" (opt "as")) impls))))
          (uiop:run-program (format nil "hdiutil detach \"~A\"" mount-dir))))

--- a/lisp/install-allegro.lisp
+++ b/lisp/install-allegro.lisp
@@ -55,7 +55,7 @@
                          (uiop:run-program
                           (format nil "hdiutil attach ~A | awk -F '\t' 'END{print $NF}'" (opt "download.archive"))
                           :output :string))))
-         (uiop:run-program (format nil "cp -r \"~A/AllegroCLexpress.app/Contents/Resources/\" \"~A\""
+         (uiop:run-program (format nil "cp -r \"~A/AllegroCLexpress64.app/Contents/Resources/\" \"~A\""
                                    mount-dir
                                    (ensure-directories-exist (merge-pathnames (format nil "~A/" (opt "as")) impls))))
          (uiop:run-program (format nil "hdiutil detach \"~A\"" mount-dir))))


### PR DESCRIPTION
I confirmed to be able to download the binary from franz.com with FTP. However, the path to the contents has also been updated. Thus, this patch changes the path to the executable files.

Closes #479 

