### PR TITLE
Update msys2 locations

### DIFF
--- a/lisp/install+msys2.lisp
+++ b/lisp/install+msys2.lisp
@@ -9,8 +9,21 @@
 (defvar *msys2-arch*)
 (defvar *msys2-bits*)
 
+(defun msys2-get-release (version)
+  "
+  In the new GitHub releases, the release name is a date with dashes
+  and the version is a date without.
+  "
+  (if (equal (length version) 8)
+    (format nil "~A-~A-~A"
+            (subseq version 0 4)
+            (subseq version 4 6)
+            (subseq version 6 8))
+    version))
+
 (defun msys2-get-version ()
-  '("20180531"))
+  '("20230127"))
+
 ;;sha1 "309f604a165179d50fbe4131cf87bd160769f974"
 ;;(ironclad:byte-array-to-hex-string (ironclad:digest-file :sha1 path))
 
@@ -33,9 +46,12 @@
           (when (or (not (probe-file path))
                     (opt "download.force"))
             (download
-             (format nil "~Amsys2/Base/~A/msys2-base-~A-~A.tar.xz"
+             (format nil "~A~A/msys2-base-~A-~A.tar.xz"
                      (msys2-uri)
-                     *msys2-arch* *msys2-arch* (getf argv :version))
+                     (msys2-get-release
+                       (getf argv :version))
+                     *msys2-arch*
+                     (getf argv :version))
              path))
           (format t " done.~%")
           (expand path
@@ -67,11 +83,10 @@
                         "make zlib-devel"))
              :output t
              :error-output t))
-          
           (uiop/run-program:run-program
-           `(,(uiop:native-namestring (merge-pathnames "autorebase.bat" msys)))
-           :output t
-           :error-output t)
+            `(,(uiop:native-namestring (merge-pathnames "autorebase.bat" msys)))
+            :output t
+            :error-output t) 
           (setf (config "msys2.version") (getf argv :version)))))
   (cons t argv))
 

--- a/lisp/locations.lisp
+++ b/lisp/locations.lisp
@@ -28,7 +28,7 @@
 (defuri ffcall-uri    "https://github.com/roswell/libffcall/archive/")
 
 (defuri sigsegv-uri   "http://ftpmirror.gnu.org/libsigsegv/")
-(defuri msys2-uri     "http://kent.dl.sourceforge.net/project/")
+(defuri msys2-uri     "https://github.com/msys2/msys2-installer/releases/download/")
 
 (defuri clisp-patch1-uri "https://raw.githubusercontent.com/Homebrew/homebrew/2fb8cb1a2279f80dc89900b3ebaca9e5afc90494/Library/Formula/clisp.rb")
 


### PR DESCRIPTION
MSYS2's download locations have changed. This patch reflects that, and installs msys2 properly with the new locations.