### PR TITLE
Fix github action build script for windows

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -35,7 +35,12 @@ jobs:
           path-type: inherit
           release: true
           update: true
-          install: 'base-devel mingw-w64-${{ matrix.arch }}-toolchain p7zip'
+          install: >-
+            base-devel
+            p7zip
+            autotools
+            mingw-w64-${{ matrix.arch }}-toolchain
+            mingw-w64-${{ matrix.arch }}-autotools
       - name: Run MSYS2 once
         shell: msys2 {0}
         run: |


### PR DESCRIPTION
as mentioned at #555, github action windows build pipeline fails.

It fails to run ./bootstrap, which try to execute aclocal, autoheader, automake, autoconf.

```
gcc version 13.2.0 (Rev2, Built by MSYS2 project) 
./bootstrap: line 2: aclocal: command not found
./bootstrap: line 3: autoheader: command not found
./bootstrap: line 4: automake: command not found
./bootstrap: line 5: autoconf: command not found
```

So I added some lines to install autotools. with that, I applied yaml strip chomping to make it easy to read.

I tested this with github action on [my forked repo](https://github.com/toracle/roswell/actions/runs/6128414514). Although it failed, due to it tried to upload the built binary to roswell repo, but build itself worked well.

```
gcc version 13.2.0 (Rev2, Built by MSYS2 project) 
configure.ac:16: installing './compile'
configure.ac:12: installing './install-sh'
configure.ac:12: installing './missing'
src/Makefile.am: installing './depcomp'
configure: loading site script /etc/config.site
checking for a BSD-compatible install... /usr/bin/install -c
checking whether build environment is sane... yes
checking for a race-free mkdir -p... /usr/bin/mkdir -p
...
```

So, this will fix #555.