### PR TITLE
This PR fixes unary operator expected error described in the issue #517

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -122,7 +122,7 @@ winrelease: roswell/Makefile
 	cp lisp/*.lisp lisp/*.ros lisp/*.el roswell/lisp
 	cd documents;MSYSTEM=MINGW64 make roswell.chm
 	cp documents/roswell.chm roswell/documents
-	7z a Roswell-`if [ $$MSYSTEM = 'MINGW64' ];then echo x86_64 ;else echo i686; fi`.zip roswell/ros.exe roswell/lisp/*.* roswell/documents/roswell.chm
+	7z a Roswell-`if [ "$$MSYSTEM" = "MINGW64" ];then echo x86_64 ;else echo i686; fi`.zip roswell/ros.exe roswell/lisp/*.* roswell/documents/roswell.chm
 debian:
 	ros debian/debian.ros all
 test:
@@ -171,7 +171,7 @@ $(PACK).tar.bz2: roswell/Makefile
 
 pack: $(PACK).tar.bz2
 
-WINPACK = roswell_$(VERSION)_$(shell if [ $$MSYSTEM = 'MINGW64' ];then echo amd64 ;else echo i686; fi)
+WINPACK = roswell_$(VERSION)_$(shell if [ "$$MSYSTEM" = "MINGW64" ];then echo amd64 ;else echo i686; fi)
 
 pack.zip: $(PACK).tar.bz2
 	7z a $(WINPACK).zip roswell


### PR DESCRIPTION
The fix already was applied to release branch, so probably this will cause a conflict if/when `master` branch will be merged into `release` branch.