### PR TITLE
Fix ROSWELL_PATH handling on Windows.

### DIFF
--- a/src/util-dir.c
+++ b/src/util-dir.c
@@ -71,9 +71,15 @@ char* currentdir(void) {
   return append_trail_slash(q_(getcwd(buf,2048)));
 }
 
+int is_valid_path(const char *path) {
+  return path[0] == '/';
+}
+
 #else
+
 char* homedir(void);
 char* currentdir(void);
+int is_valid_path(const char *);
 #endif
 
 char* configdir(void) {
@@ -82,9 +88,10 @@ char* configdir(void) {
 
   if (env) /* note: env can be a NULL */
   {
-      if (env[0] != DIRSEP[0])   /* note: DIRSEP == \\ on windows, / on unix */
+      if (!is_valid_path(env))
       {
           cond_printf(0,"Error: %s must be absolute. Got: %s \n",c,env);
+	  abort();
       }
       s(c);                     /* note : this frees c. */
       return append_trail_slash(q(env));
@@ -143,3 +150,4 @@ char* basedir(void) {
   s(cd_);
   return configdir();
 }
+

--- a/src/util-dir_windows.c
+++ b/src/util-dir_windows.c
@@ -64,4 +64,21 @@ char* currentdir(void) {
   char buf[2048];
   return append_trail_slash(q_(_getcwd(buf,2048)));
 }
+
+int is_valid_path(const char *path) {
+  //
+  // On Windows, an absolute path can technically
+  // start with a drive letter (i.e. c:\roswell),
+  // but could also be a UNC path (i.e. \\OTHERMACHINE\roswell).
+  //
+  // But, if invoked inside an msys2 shell we could get a UNIX-style path.
+  //
+  // It appears however that the latter two scenarios are not supported
+  // by other parts of the codebase, so we shall enforce here that only
+  // regular Windows-style paths are allowed.
+  //
+
+  return (isalpha(path[0]) && path[1] == ':'  && (path[2] == '\\' || path[2] == '/'));
+}
+
 #endif

--- a/src/util.h
+++ b/src/util.h
@@ -13,6 +13,7 @@
 #include <string.h>
 #include <stdarg.h>
 #ifndef HAVE_WINDOWS_H
+#include <ctype.h>
 #include <pwd.h>
 #include <unistd.h>
 #include <grp.h>
@@ -142,6 +143,7 @@ int directory_exist_p (char* path);
 int change_directory(const char* path);
 int delete_directory(char* pathspec,int recursive);
 char* impldir(char* arch,char* os,char* impl,char* version);
+int is_valid_path(const char *path);
 /*util_file.c */
 int delete_file(char* pathspec);
 int rename_file(char* file,char* new_name);


### PR DESCRIPTION
This properly detects whether the ROSWELL_HOME directory is valid. And, in case it is not, abort() rather than mindlessly continuing.

On Windows, setting it to c:\roswell (for example) would cause the install to fail. This diff fixes that.

Furthermore, there are three kinds of paths you could reasonably encounter on Windows:
- traditional DOS-style paths: i.e. c:\roswell
- UNC paths: i.e. \\othermachine\roswell
- Or, when running in an msys2 shell (for example), unix paths: /c/roswell

I called this out in an explanatory comment but have not allowed the latter two to be valid on Windows. The reason being is that other parts of the installer cannot handle UNC paths or being called from an msys2 shell with a UNIX-style path set. I have no interest in fixing those issues, so if presented with that my fix will say those paths are invalid.

Here's some testing:
```
d:\build\bin>echo %ROSWELL_HOME%
c:\roswell

d:\build\bin>.\ros.exe
Installing sbcl-bin...
No SBCL version specified. Downloading sbcl-bin_uri.tsv to see the available versions...
[##########################################################################]100%
Installing sbcl-bin/2.4.9...
Downloading https://github.com/roswell/sbcl_bin/releases/download/2.4.9/sbcl-2.4.9-x86-64-windows-binary.msi
[##########################################################################]100%
Extracting the msi archive. sbcl-bin-2.4.9-x86-64-windows.msi to c:\roswell\src\sbcl-2.4.9-x86-64-windows\
Install Script for sbcl-bin...
Installing Quicklisp... Done 8630
Making core for Roswell...
Common Lisp environment setup Utility.

Usage:

   NIL [options] Command [arguments...]
or
   NIL [options] [[--] script-path arguments...]

commands:
   run       Run repl
   install   Install a given implementation or a system for roswell environment
   update    Update installed systems.
   build     Make executable from script.
   use       Change default implementation.
   init      Creates a new ros script, optionally based on a template.
   fmt       Indent lisp source.
   list      List Information
   template  Manage templates
   delete    Delete installed implementations
   config    Get and set options
   version   Show the roswell version information

Use "ros help [command]" for more information about a command.

Additional help topics:

   options

Use "ros help [topic]" for more information about the topic.
````

and

```
d:\build\bin>echo %ROSWELL_HOME%
..\..\test

d:\build\bin>ros
Error: ROSWELL_HOME must be absolute. Got: ..\..\test

d:\build\bin>
```

This also seems like a fairly fundamental thing that should be tested. But I could not find anywhere to add such a test. Please advise if there is so I can add one.