### PR TITLE
Upgrade allegro CL to release 11.0express, beta version unavailable yet

### DIFF
--- a/lisp/install-allegro.lisp
+++ b/lisp/install-allegro.lisp
@@ -13,7 +13,7 @@
                               (version (getf argv :version)))
   (let ((os (intern uname :keyword))
         (machine (intern uname-m :keyword)))
-    (cond ((find version '("11.0bexpress"
+    (cond ((find version '("11.0express"
                            "10.1express")
                  :test 'equal)
            (format nil "~@{~A~}"

--- a/lisp/locations.lisp
+++ b/lisp/locations.lisp
@@ -54,7 +54,7 @@
 
 (export
  (defvar *allegro-agreement-uri*
-   '(#+darwin ("11.0bexpress" . "https://franz.com/ftp/pub/legal/ACL-Express-20170301.pdf")
+   '(#+darwin ("11.0express" . "https://franz.com/ftp/pub/legal/ACL-Express-20170301.pdf")
      ("10.1express" . #1="https://franz.com/ftp/pub/legal/ACL-Express-20170301.pdf")
      ("100express"  . #1#)
      ("101b"        . "http://franz.com/products/licensing/FSLA10.1.beta.pdf"))))


### PR DESCRIPTION
Current allegro default version `11.0bexpress` has been replaced by final release. I encountered following error when running `ros install allegro`

```
Installing allegro/11.0bexpress...
Downloading https://franz.com/ftp/pub/acl11.0bexpress/macosx86-64.64/acl11.0bexpress-macos-x64.dmg
Downloading archive:https://franz.com/ftp/pub/acl11.0bexpress/macosx86-64.64/acl11.0bexpress-macos-x64.dmg:NG
Downloading https://franz.com/ftp/pub/acl11.0bexpress/macosx86-64.64/acl11.0bexpress-macos-x64.dmg
Downloading archive:https://franz.com/ftp/pub/acl11.0bexpress/macosx86-64.64/acl11.0bexpress-macos-x64.dmg:NG
Downloading https://franz.com/ftp/pub/acl11.0bexpress/macosx86-64.64/acl11.0bexpress-macos-x64.dmg
Downloading archive:https://franz.com/ftp/pub/acl11.0bexpress/macosx86-64.64/acl11.0bexpress-macos-x64.dmg:NG
Downloading https://franz.com/ftp/pub/acl11.0bexpress/macosx86-64.64/acl11.0bexpress-macos-x64.dmg
Downloading archive:https://franz.com/ftp/pub/acl11.0bexpress/macosx86-64.64/acl11.0bexpress-macos-x64.dmg:NG

Extracting archive:/Users/chenxm/.roswell/archives/acl11.0bexpress-macos-x64.dmg
Unhandled UIOP/RUN-PROGRAM:SUBPROCESS-ERROR in thread #<SB-THREAD:THREAD tid=259 "main thread" RUNNING
                                                         {1003F90003}>:
  Subprocess with command "cp -r \"/AllegroCL64express.app/Contents/Resources/\" \"/Users/chenxm/.roswell/impls/x86-64/darwin/allegro/11.0bexpress/\""
 exited with error code 1

Backtrace for: #<SB-THREAD:THREAD tid=259 "main thread" RUNNING {1003F90003}>
0: (SB-DEBUG::DEBUGGER-DISABLED-HOOK #<UIOP/RUN-PROGRAM:SUBPROCESS-ERROR {10034D17A3}> #<unused argument> :QUIT T)
1: (SB-DEBUG::RUN-HOOK SB-EXT:*INVOKE-DEBUGGER-HOOK* #<UIOP/RUN-PROGRAM:SUBPROCESS-ERROR {10034D17A3}>)
2: (INVOKE-DEBUGGER #<UIOP/RUN-PROGRAM:SUBPROCESS-ERROR {10034D17A3}>)
3: (CERROR "IGNORE-ERROR-STATUS" UIOP/RUN-PROGRAM:SUBPROCESS-ERROR :COMMAND "cp -r \"/AllegroCL64express.app/Contents/Resources/\" \"/Users/chenxm/.roswell/impls/x86-64/darwin/allegro/11.0bexpress/\"" :CODE 1 :PROCESS NIL)
4: (UIOP/RUN-PROGRAM::%CHECK-RESULT 1 :COMMAND "cp -r \"/AllegroCL64express.app/Contents/Resources/\" \"/Users/chenxm/.roswell/impls/x86-64/darwin/allegro/11.0bexpress/\"" :PROCESS NIL :IGNORE-ERROR-STATUS NIL)
5: (UIOP/RUN-PROGRAM::%USE-SYSTEM "cp -r \"/AllegroCL64express.app/Contents/Resources/\" \"/Users/chenxm/.roswell/impls/x86-64/darwin/allegro/11.0bexpress/\"")
6: (ROSWELL.INSTALL.ALLEGRO::ALLEGRO-EXPAND (:TARGET "allegro" :VERSION "11.0bexpress" :VERSION-NOT-SPECIFIED 4 :ARGV NIL))
7: (INSTALL-IMPL "allegro" NIL NIL (#<FUNCTION (LAMBDA (ROSWELL.INSTALL::ARGV) :IN DECIDE-VERSION) {10034A71EB}> ROSWELL.INSTALL.ALLEGRO::ALLEGRO-ARGV-PARSE #<FUNCTION (LAMBDA (ROSWELL.INSTALL::ARGV) :IN DECIDE-DOWNLOAD) {10034A720B}> ROSWELL.INSTALL.ALLEGRO::ALLEGRO-EXPAND SETUP))
8: (INSTALL-IMPL-IF-PROBED "allegro" NIL #<unavailable argument>)
9: (INSTALL NIL)
10: (SB-INT:SIMPLE-EVAL-IN-LEXENV (APPLY (QUOTE MAIN) ROSWELL:*ARGV*) #<NULL-LEXENV>)
11: (SB-INT:SIMPLE-EVAL-IN-LEXENV (ROSWELL:QUIT (APPLY (QUOTE MAIN) ROSWELL:*ARGV*)) #<NULL-LEXENV>)
12: (SB-EXT:EVAL-TLF (ROSWELL:QUIT (APPLY (QUOTE MAIN) ROSWELL:*ARGV*)) NIL NIL)
13: ((LABELS SB-FASL::EVAL-FORM :IN SB-INT:LOAD-AS-SOURCE) (ROSWELL:QUIT (APPLY (QUOTE MAIN) ROSWELL:*ARGV*)) NIL)
14: (SB-INT:LOAD-AS-SOURCE #<CONCATENATED-STREAM :STREAMS NIL {1002206AA3}> :VERBOSE NIL :PRINT NIL :CONTEXT "loading")
15: ((LABELS SB-FASL::LOAD-STREAM-1 :IN LOAD) #<CONCATENATED-STREAM :STREAMS NIL {1002206AA3}> NIL)
16: (SB-FASL::CALL-WITH-LOAD-BINDINGS #<FUNCTION (LABELS SB-FASL::LOAD-STREAM-1 :IN LOAD) {C2EF5DB}> #<CONCATENATED-STREAM :STREAMS NIL {1002206AA3}> NIL #<CONCATENATED-STREAM :STREAMS NIL {1002206AA3}>)
17: (LOAD #<CONCATENATED-STREAM :STREAMS NIL {1002206AA3}> :VERBOSE NIL :PRINT NIL :IF-DOES-NOT-EXIST :ERROR :EXTERNAL-FORMAT :DEFAULT)
18: ((FLET ROSWELL::BODY :IN ROSWELL:SCRIPT) #<SB-SYS:FD-STREAM for "file /usr/local/Cellar/roswell/23.10.14.114/etc/roswell/install.ros" {1002203933}>)
19: (ROSWELL:SCRIPT "/usr/local/Cellar/roswell/23.10.14.114/etc/roswell/install.ros" "allegro")
20: (ROSWELL:RUN ((:EVAL "(ros:quicklisp)") (:SCRIPT "/usr/local/Cellar/roswell/23.10.14.114/etc/roswell/install.ros" "allegro") (:QUIT NIL)))
21: (SB-INT:SIMPLE-EVAL-IN-LEXENV (ROSWELL:RUN (QUOTE ((:EVAL "(ros:quicklisp)") (:SCRIPT "/usr/local/Cellar/roswell/23.10.14.114/etc/roswell/install.ros" "allegro") (:QUIT NIL)))) #<NULL-LEXENV>)
22: (EVAL (ROSWELL:RUN (QUOTE ((:EVAL "(ros:quicklisp)") (:SCRIPT "/usr/local/Cellar/roswell/23.10.14.114/etc/roswell/install.ros" "allegro") (:QUIT NIL)))))
23: (SB-IMPL::PROCESS-EVAL/LOAD-OPTIONS ((:EVAL . "(progn #-ros.init(cl:load \"/usr/local/Cellar/roswell/23.10.14.114/etc/roswell/init.lisp\"))") (:EVAL . "(ros:run '((:eval\"(ros:quicklisp)\")(:script \"/usr/local/Cellar/roswell/23.10.14.114/etc/roswell/install.ros\"\"allegro\")(:quit ())))")))
24: (SB-IMPL::TOPLEVEL-INIT)
25: ((FLET SB-UNIX::BODY :IN SB-IMPL::START-LISP))
26: ((FLET "WITHOUT-INTERRUPTS-BODY-3" :IN SB-IMPL::START-LISP))
27: (SB-IMPL::%START-LISP)
```