### PR TITLE
Generate standalone executable and optimize executable options added to compilation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ src/ros.exe
 src/html_sbcl
 src/html_sbcl.exe
 src/gend.h
+src/standalone-lisp.c
+src/standalone-patch.c
 /Makefile
 /src/Makefile
 /documents/Makefile

--- a/configure.ac
+++ b/configure.ac
@@ -142,6 +142,24 @@ AC_ARG_ENABLE([html_generation],
    esac],[])
 AM_CONDITIONAL(HTML_GENERATE,[test x$html_generate = x"true"])
 
+AC_ARG_ENABLE([standalone_executable],
+  [AS_HELP_STRING([--enable-standalone-executable],[generate standalone executable if enabled])],
+  [case "${enableval}" in
+    yes) standalone_executable=true ;;
+    no)  standalone_executable=false ;;
+    *) AC_MSG_ERROR([bad value ${enableval} for --enable-standalone-executable]) ;;
+   esac],[])
+AM_CONDITIONAL(STANDALONE_EXECUTABLE,[test x$standalone_executable = x"true"])
+
+AC_ARG_ENABLE([optimize_executable],
+  [AS_HELP_STRING([--enable-optimize-executable],[optimize executable if enabled])],
+  [case "${enableval}" in
+    yes) optimize_executable=true ;;
+    no)  optimize_executable=false ;;
+    *) AC_MSG_ERROR([bad value ${enableval} for --enable-optimize-executable]) ;;
+   esac],[])
+AM_CONDITIONAL(OPTIMIZE_EXECUTABLE,[test x$optimize_executable = x"true"])
+
 AM_COND_IF([MANUAL_INSTALL],
            [AC_CONFIG_FILES([documents/Makefile])])
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -35,20 +35,18 @@ endif
 	cat $@
 	rm -f $@.tmp
 if STANDALONE_EXECUTABLE
-	echo "#include \"util.h\"" > standalone-lisp.c && \
-	echo "#include \"gend.h\"" >> standalone-lisp.c && \
-	ls ../lisp | awk '{ s=$$1; gsub(/[-.+]/, "_", s); print "extern char _binary_"s"_start[];extern char _binary_"s"_end[];"; }' >> ../src/standalone-lisp.c && \
-	echo "void init_standalone_lisp_files() {" >> standalone-lisp.c && \
-	ls ../lisp | awk '{ s=$$1; gsub(/[-.+]/, "_", s); print "  write_standalone_file(LISP_PATH, \""$$1"\", _binary_"s"_start, _binary_"s"_end - _binary_"s"_start);"; }' >> ../src/standalone-lisp.c && \
+	echo "#include \"util.h\"" > standalone-lisp.c
+	echo "#include \"gend.h\"" >> standalone-lisp.c
+	cd ../lisp && for file in *; do xxd -i $$file >> ../src/standalone-lisp.c; done
+	echo "void init_standalone_lisp_files() {" >> standalone-lisp.c
+	ls ../lisp | awk '{ s=$$1; gsub(/[-.+]/, "_", s); print "  write_standalone_file(LISP_PATH, \""$$1"\", "s", "s"_len);"; }' >> ../src/standalone-lisp.c
 	echo "}" >> standalone-lisp.c
-	cd ../lisp && ld -r -z noexecstack -b binary -o ../src/lisp.o *
-	echo "#include \"util.h\"" > standalone-patch.c && \
-	echo "#include \"gend.h\"" >> standalone-patch.c && \
-	ls ../patch | awk '{ s=$$1; gsub(/[-.+]/, "_", s); print "extern char _binary_"s"_start[];extern char _binary_"s"_end[];"; }' >> ../src/standalone-patch.c && \
-	echo "void init_standalone_patch_files() {" >> standalone-patch.c && \
-	ls ../patch | awk '{ s=$$1; gsub(/[-.+]/, "_", s); print "  write_standalone_file(PATCH_PATH, \""$$1"\", _binary_"s"_start, _binary_"s"_end - _binary_"s"_start);"; }' >> ../src/standalone-patch.c && \
+	echo "#include \"util.h\"" > standalone-patch.c
+	echo "#include \"gend.h\"" >> standalone-patch.c
+	cd ../patch && for file in *; do xxd -i $$file >> ../src/standalone-patch.c; done
+	echo "void init_standalone_patch_files() {" >> standalone-patch.c
+	ls ../patch | awk '{ s=$$1; gsub(/[-.+]/, "_", s); print "  write_standalone_file(PATCH_PATH, \""$$1"\", "s", "s"_len);"; }' >> ../src/standalone-patch.c
 	echo "}" >> standalone-patch.c
-	cd ../patch && ld -r -z noexecstack -b binary -o ../src/patch.o *
 endif
 
 cmd-internal.o: gend.h
@@ -71,7 +69,6 @@ resources.o: resources.rc
 endif
 
 if STANDALONE_EXECUTABLE
-ros_LDADD += lisp.o patch.o
 ros_SOURCES += util-standalone.c standalone-lisp.c standalone-patch.c
 endif
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -12,15 +12,44 @@ gend.h: FORCE
 	printf '#define ROS_REVISION "@git_version@"\n' >> $@.tmp
 	printf '#define UNAME_M "@uname_m@"\n' >> $@.tmp
 	printf '#define UNAME_S "@uname_s@"\n' >> $@.tmp
+if STANDALONE_EXECUTABLE
+	printf '#define STANDALONE_EXECUTABLE true\n' >> $@.tmp
+	printf 'void init_standalone_dir();\n' >> $@.tmp
+	printf 'void write_standalone_file(const char *dir, const char* name, char *val, unsigned int size);\n' >> $@.tmp
+	printf 'void init_standalone_lisp_files();\n' >> $@.tmp
+	printf 'void init_standalone_patch_files();\n' >> $@.tmp
+	printf '#define PATCH_PATH "/tmp/roswell-@git_version@/patch"\n' >> $@.tmp
+else
 	printf '#define PATCH_PATH "@roslisppatchdir@"\n' >> $@.tmp
+endif
 if WITH_WINDOWS
 	printf '#define LISP_PATH "%s"\n' "`mkdir -p @roslispdir@;cd @roslispdir@; pwd -W 2>/dev/null`" >> $@.tmp
 else
+if STANDALONE_EXECUTABLE
+	printf '#define LISP_PATH "/tmp/roswell-@git_version@/lisp"\n' >> $@.tmp
+else
 	printf '#define LISP_PATH "@roslispdir@"\n' >> $@.tmp
+endif
 endif
 	cmp -s $@.tmp $@||cp $@.tmp $@
 	cat $@
 	rm -f $@.tmp
+if STANDALONE_EXECUTABLE
+	echo "#include \"util.h\"" > standalone-lisp.c && \
+	echo "#include \"gend.h\"" >> standalone-lisp.c && \
+	ls ../lisp | awk '{ s=$$1; gsub(/[-.+]/, "_", s); print "extern char _binary_"s"_start[];extern char _binary_"s"_end[];"; }' >> ../src/standalone-lisp.c && \
+	echo "void init_standalone_lisp_files() {" >> standalone-lisp.c && \
+	ls ../lisp | awk '{ s=$$1; gsub(/[-.+]/, "_", s); print "  write_standalone_file(LISP_PATH, \""$$1"\", _binary_"s"_start, _binary_"s"_end - _binary_"s"_start);"; }' >> ../src/standalone-lisp.c && \
+	echo "}" >> standalone-lisp.c
+	cd ../lisp && ld -r -z noexecstack -b binary -o ../src/lisp.o *
+	echo "#include \"util.h\"" > standalone-patch.c && \
+	echo "#include \"gend.h\"" >> standalone-patch.c && \
+	ls ../patch | awk '{ s=$$1; gsub(/[-.+]/, "_", s); print "extern char _binary_"s"_start[];extern char _binary_"s"_end[];"; }' >> ../src/standalone-patch.c && \
+	echo "void init_standalone_patch_files() {" >> standalone-patch.c && \
+	ls ../patch | awk '{ s=$$1; gsub(/[-.+]/, "_", s); print "  write_standalone_file(PATCH_PATH, \""$$1"\", _binary_"s"_start, _binary_"s"_end - _binary_"s"_start);"; }' >> ../src/standalone-patch.c && \
+	echo "}" >> standalone-patch.c
+	cd ../patch && ld -r -z noexecstack -b binary -o ../src/patch.o *
+endif
 
 cmd-internal.o: gend.h
 util.o: gend.h
@@ -41,9 +70,19 @@ resources.o: resources.rc
 	@WINDRES@ $^ -o $@
 endif
 
+if STANDALONE_EXECUTABLE
+ros_LDADD += lisp.o patch.o
+ros_SOURCES += util-standalone.c standalone-lisp.c standalone-patch.c
+endif
+
 noinst_HEADERS = util.h opt.h cmd-install.h gend.h cmd-run.h
 
-CLEANFILES = gend.h
+CLEANFILES = gend.h standalone-lisp.c standalone-patch.c
+
+if OPTIMIZE_EXECUTABLE
+all-local:
+	upx ros
+endif
 
 check-syntax:
 	$(CC) -Wall -fsyntax-only $(CHK_SOURCES)

--- a/src/main.c
+++ b/src/main.c
@@ -1,4 +1,5 @@
 #include "opt.h"
+#include "gend.h"
 
 char** argv_orig;
 int argc_orig;
@@ -13,6 +14,10 @@ int main(int argc,char **argv) {
   char* path=s_cat(configdir(),q("config"),NULL);
   argv_orig=argv;
   argc_orig=argc;
+
+#ifdef STANDALONE_EXECUTABLE
+  init_standalone_dir();
+#endif
 
   lispdir();
   register_top(&top);

--- a/src/util-file.c
+++ b/src/util-file.c
@@ -1,4 +1,5 @@
 #include "util.h"
+#include <fcntl.h>
 
 #ifndef HAVE_WINDOWS_H
 
@@ -41,6 +42,16 @@ long file_mtime(char* path) {
 int file_newer_p(char* a,char* b) {
   long at=file_mtime(a),bt=file_mtime(b);
   return bt==0?1:(at!=0&& at>=bt);
+}
+
+int file_write_data(char* path, char* data, unsigned int size) {
+  int fd=open(path, O_CREAT | O_WRONLY, S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH);
+  if (fd > 0) {
+      write(fd, data, size);
+      close(fd);
+  } else {
+      return fd;
+  }
 }
 #endif
 

--- a/src/util-file.c
+++ b/src/util-file.c
@@ -44,7 +44,7 @@ int file_newer_p(char* a,char* b) {
   return bt==0?1:(at!=0&& at>=bt);
 }
 
-int file_write_data(char* path, char* data, unsigned int size) {
+int file_write_data(char* path, char* data, size_t size) {
   int fd=open(path, O_CREAT | O_WRONLY, S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH);
   if (fd > 0) {
       write(fd, data, size);

--- a/src/util-file_windows.c
+++ b/src/util-file_windows.c
@@ -1,4 +1,6 @@
 #include "util.h"
+#include <stdio.h>
+#include <stdlib.h>
 
 #ifdef HAVE_WINDOWS_H
 
@@ -31,7 +33,13 @@ int file_newer_p(char * a,char* b) {
   return 0;
 }
 
-int file_write_data(char* path, char* data, unsigned int size) {
-    // unimplemented on windows and unused
+int file_write_data(char* path, char* data, size_t size) {
+  FILE* file = fopen(path, "wb");
+  if (file == NULL) {
+    return -1;
+  }
+  size_t out = fwrite(data, sizeof(char), size, file);
+  fclose(file);
+  return out!=size?-1:0;
 }
 #endif

--- a/src/util-file_windows.c
+++ b/src/util-file_windows.c
@@ -30,4 +30,8 @@ long file_mtime(char* path) {
 int file_newer_p(char * a,char* b) {
   return 0;
 }
+
+int file_write_data(char* path, char* data, unsigned int size) {
+    // unimplemented on windows and unused
+}
 #endif

--- a/src/util-standalone.c
+++ b/src/util-standalone.c
@@ -1,0 +1,26 @@
+#include "util.h"
+#include "gend.h"
+#include <stdio.h>
+
+void init_standalone_dir() {
+  if (!directory_exist_p(LISP_PATH)) {
+    char *dir = append_trail_slash(q(LISP_PATH));
+    ensure_directories_exist(dir);
+    s(dir);
+    init_standalone_lisp_files();
+  }
+  if (!directory_exist_p(PATCH_PATH)) {
+    char *dir = append_trail_slash(q(PATCH_PATH));
+    ensure_directories_exist(dir);
+    s(dir);
+    init_standalone_patch_files();
+  }
+}
+
+void write_standalone_file(const char *dir, const char* name, char *data, unsigned int size) {
+  char *file_name = s_cat(append_trail_slash(q(dir)), q(name), NULL);
+  if (!file_exist_p(file_name)) {
+    file_write_data(file_name, data, size);
+  }
+  s(file_name);
+}

--- a/src/util.h
+++ b/src/util.h
@@ -151,6 +151,7 @@ void touch(char* path);
 int file_exist_p (char* path);
 long file_mtime(char* path);
 int file_newer_p(char * a,char* b);
+int file_write_data(char* path, char* data, unsigned int size);
 /*util_system.c */
 char* system_(char* cmd);
 int system_redirect(const char* cmd,char* filename);

--- a/src/util.h
+++ b/src/util.h
@@ -151,7 +151,7 @@ void touch(char* path);
 int file_exist_p (char* path);
 long file_mtime(char* path);
 int file_newer_p(char * a,char* b);
-int file_write_data(char* path, char* data, unsigned int size);
+int file_write_data(char* path, char* data, size_t size);
 /*util_system.c */
 char* system_(char* cmd);
 int system_redirect(const char* cmd,char* filename);


### PR DESCRIPTION
This draft PR adds two options to configure, --enable-standalone-executable and --enable-optimize-executable

first option depends on xxd utility and is fully working on both Linux and Macos but can be easily adapted to work on Windows too

second option depends on upx utility and is currently only working on Linux and probably works on Windows but I haven't tested it yet however unfortunately upx currently doesn't support Macos yet

The method of how it works is it embeds all files in lisp and patch folders and unpacks them into /tmp/roswell-$version directories if they don't exist.

Having standalone executable is very handy especially for distributing executable using projects like Aqua and ubi and then installing them using tools like asdf or mise

Fully packed with upx standalone ros executable is 123kb on Linux 