### PR TITLE
Fix declaration-definition disagreement in src/cmd-run.h (see Issue #604)

### DIFF
--- a/src/cmd-run.h
+++ b/src/cmd-run.h
@@ -24,7 +24,7 @@ extern char** cmd_run_acl(int argc,char** argv,struct sub_command* cmd);
 extern char** cmd_run_lispworks(int argc,char** argv,struct sub_command* cmd);
 extern char** cmd_run_mkcl(int argc,char** argv,struct sub_command* cmd);
 extern char** cmd_run_npt(int argc,char** argv,struct sub_command* cmd);
-extern LVal register_runtime_options(struct proc_opt* cmd);
+extern struct proc_opt* register_runtime_options(struct proc_opt* cmd);
 int setup(char* target,char* env,char* impl);
 #define SETUP_SYSTEM(sys,msg) {\
     cond_printf(0,"%s",msg);   \


### PR DESCRIPTION
PR created according to Issue #604 
Definition at [src/register-commands.c L63](https://github.com/roswell/roswell/blob/feb5647990c49ede4e082a7f2e859dd8104125ad/src/register-commands.c#L63):
```c
struct proc_opt* register_runtime_options(struct proc_opt* cmd);
```
Reference at [src/cmd-run.h L27](https://github.com/roswell/roswell/blob/feb5647990c49ede4e082a7f2e859dd8104125ad/src/cmd-run.h#L27):
```diff
- extern LVal register_runtime_options();
+ extern struct proc_opt* register_runtime_options(struct proc_opt* cmd);
```
This disagreement leads to a compilation error when building with GCC 15.1.1, and the error disappears after patching.